### PR TITLE
⚡ Spark: Add camelCase and kebabCase transforms to valueTransforms

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - [Centralized String Transforms]
+**Learning:** Using a centralized utility for string transformations (`valueTransforms`) and then leveraging TypeScript's `Parameters<typeof valueTransforms>[1]` in UI components (like `Input`) ensures that new transformations are automatically available and type-safe across the entire library.
+**Pattern:** Export a transform utility with a union type for its options, and use `Parameters<typeof fn>[index]` to type props in components that consume it.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Custom input component supporting transformations, debounce, datalist, and more.
 | Prop                | Type                                | Description                             |
 |---------------------|-------------------------------------|------------------------------------------|
 | `label`             | `string`                            | Optional label                          |
-| `transform`         | `string` (`"titleCase"`, `"onlyEmail"`...) | Built-in value transforms         |
+| `transform`         | `string` (`"camelCase"`, `"kebabCase"`, `"titleCase"`, `"onlyEmail"`...) | Built-in value transforms         |
 | `transformFn`       | `(value: string) => string`         | Custom value transform                   |
 | `onChangeValue`     | `(value: string) => void`           | Fires on value change                    |
 | `onChangeDebounce`  | `(value: string) => void`           | Fires after debounce                     |

--- a/lib/utilities/strings.test.ts
+++ b/lib/utilities/strings.test.ts
@@ -22,6 +22,18 @@ describe('valueTransforms', () => {
         expect(valueTransforms('hello world', 'snakeCase')).toBe('hello_world')
     })
 
+    it('should transform to camel case', () => {
+        expect(valueTransforms('hello world', 'camelCase')).toBe('helloWorld')
+        expect(valueTransforms('hello-world', 'camelCase')).toBe('helloWorld')
+        expect(valueTransforms('hello_world', 'camelCase')).toBe('helloWorld')
+    })
+
+    it('should transform to kebab case', () => {
+        expect(valueTransforms('hello world', 'kebabCase')).toBe('hello-world')
+        expect(valueTransforms('helloWorld', 'kebabCase')).toBe('hello-world')
+        expect(valueTransforms('hello_world', 'kebabCase')).toBe('hello-world')
+    })
+
     it('should remove all non-numeric characters', () => {
         expect(valueTransforms('a1b2c3', 'onlyNumbers')).toBe('123')
     })
@@ -45,7 +57,7 @@ describe('valueTransforms', () => {
     })
 
     it('should return the original value if an invalid transform is provided', () => {
-        // @ts-expect-error
+        // @ts-expect-error - testing invalid transform
         expect(valueTransforms('hello', 'invalidTransform')).toBe('hello')
     })
 })

--- a/lib/utilities/strings.ts
+++ b/lib/utilities/strings.ts
@@ -6,6 +6,8 @@ export const valueTransforms = (
     | "capitalize"
     | "titleCase"
     | "snakeCase"
+    | "camelCase"
+    | "kebabCase"
     | "onlyNumbers"
     | "onlyLetters"
     | "onlyEmail"
@@ -22,6 +24,19 @@ export const valueTransforms = (
       return value.toLowerCase().replace(/\b\w/g, (ch) => ch.toUpperCase());
     case "snakeCase":
       return value.toLowerCase().replace(/\s/g, "_");
+    case "camelCase":
+      return value
+        .replace(/([a-z])([A-Z])/g, "$1 $2")
+        .replace(/[_-]/g, " ")
+        .replace(/(?:^\w|[A-Z]|\b\w)/g, (word, index) =>
+          index === 0 ? word.toLowerCase() : word.toUpperCase(),
+        )
+        .replace(/\s+/g, "");
+    case "kebabCase":
+      return value
+        .replace(/([a-z])([A-Z])/g, "$1-$2")
+        .replace(/[\s_]+/g, "-")
+        .toLowerCase();
     case "onlyNumbers":
       return value.replace(/\D/g, "");
     case "onlyLetters":

--- a/src/Examples/InputExample.tsx
+++ b/src/Examples/InputExample.tsx
@@ -45,6 +45,8 @@ export const InputExample = () => {
                         <option value="capitalize">Capitalize</option>
                         <option value="titleCase">Title Case</option>
                         <option value="snakeCase">Snake Case</option>
+                        <option value="camelCase">Camel Case</option>
+                        <option value="kebabCase">Kebab Case</option>
                         <option value="onlyNumbers">Only Numbers</option>
                         <option value="onlyLetters">Only Letters</option>
                         <option value="onlyEmail">Only Email</option>

--- a/src/pages/input/useInputPage.tsx
+++ b/src/pages/input/useInputPage.tsx
@@ -37,6 +37,8 @@ export const UseInputPage = () => {
                             <li><code>capitalize</code> - Capitalize first letter</li>
                             <li><code>titleCase</code> - Title case each word</li>
                             <li><code>snakeCase</code> - Convert to snake_case</li>
+                            <li><code>camelCase</code> - Convert to camelCase</li>
+                            <li><code>kebabCase</code> - Convert to kebab-case</li>
                             <li><code>onlyNumbers</code> - Keep only numbers</li>
                             <li><code>onlyLetters</code> - Keep only letters</li>
                             <li><code>onlyEmail</code> - Email format validation</li>
@@ -80,6 +82,8 @@ export const UseInputPage = () => {
                                     <option value="capitalize">Capitalize</option>
                                     <option value="titleCase">Title Case</option>
                                     <option value="snakeCase">Snake Case</option>
+                                    <option value="camelCase">Camel Case</option>
+                                    <option value="kebabCase">Kebab Case</option>
                                     <option value="onlyNumbers">Only Numbers</option>
                                     <option value="onlyLetters">Only Letters</option>
                                     <option value="onlyEmail">Only Email</option>


### PR DESCRIPTION
💡 **What:** Added `camelCase` and `kebabCase` transformations to the `valueTransforms` string utility.
🎯 **Why:** To provide more flexible string manipulation options that are commonly needed in UI development, especially for normalizing input values or formatting labels.
📦 **What it adds:** 
- `camelCase`: Converts strings to `camelCase` (e.g., "hello world" -> "helloWorld", "hello-world" -> "helloWorld").
- `kebabCase`: Converts strings to `kebab-case` (e.g., "hello world" -> "hello-world", "helloWorld" -> "hello-world").
🚀 **How to use:**
```typescript
import { valueTransforms } from './lib/utilities/strings';

valueTransforms('hello world', 'camelCase'); // 'helloWorld'
valueTransforms('Hello World', 'kebabCase'); // 'hello-world'
```
♻️ **Deps Free:** Confirmation: No new dependencies were added.
🎨 **Harmony:** Fits perfectly with the existing `valueTransforms` utility and is automatically supported by the `Input` component through its existing type definitions.

---
*PR created automatically by Jules for task [14760143219285044848](https://jules.google.com/task/14760143219285044848) started by @galiprandi*