### PR TITLE
🛡️ Sentinel: Prevent prototype pollution in Form component

### DIFF
--- a/.axioma/sentinel.md
+++ b/.axioma/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-11 - Prototype Pollution in Form Data Collection
+**Vulnerability:** The `Form` component was vulnerable to prototype pollution when collecting values from `FormData`.
+**Learning:** Blindly spreading `FormData` entries into an object allows an attacker to inject properties like `__proto__`, `constructor`, or `prototype`, which can lead to prototype pollution.
+**Prevention:** Always validate or filter keys from untrusted input before assigning them to objects. Use direct assignment or `Object.create(null)` for result objects. Note that 'happy-dom' test environment crashes if an HTML input has a 'name' attribute equal to these reserved keys, so mocking 'FormData' is preferred for testing.

--- a/lib/components/Form/index.tsx
+++ b/lib/components/Form/index.tsx
@@ -44,10 +44,19 @@ export const Form = <T,>(props: FormProps<T>): JSX.Element => {
         if (onSubmitValues) {
             const formData = new FormData(event.currentTarget)
             const entries = formData.entries()
-            let values = {} as T
+            const values = {} as T
             for (const [key, value] of entries) {
+                // Security check: prevent prototype pollution
+                if (
+                    key === '__proto__' ||
+                    key === 'constructor' ||
+                    key === 'prototype'
+                ) {
+                    continue
+                }
+
                 if (filterEmptyValues && !value) continue
-                values = { ...values, [key]: value }
+                ;(values as Record<string, unknown>)[key] = value
             }
 
             onSubmitValues(values)

--- a/lib/components/Form/security.test.tsx
+++ b/lib/components/Form/security.test.tsx
@@ -1,0 +1,50 @@
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { Form } from './index'
+import React from 'react'
+
+describe('Form Security', () => {
+    it('should ignore dangerous keys to prevent prototype pollution', () => {
+        const onSubmitValues = vi.fn()
+
+        // We use a different way to trigger the submission with dangerous data
+        // since happy-dom crashes if we put them in 'name' attribute of an input
+
+        const { container } = render(
+            <Form onSubmitValues={onSubmitValues}>
+                <input name="normal" defaultValue="value" />
+                <button type="submit">Submit</button>
+            </Form>
+        )
+
+        const form = container.querySelector('form')
+
+        // Mock FormData to return dangerous keys
+        const originalFormData = window.FormData;
+        window.FormData = vi.fn().mockImplementation(() => ({
+            entries: () =>
+                [
+                    ['normal', 'value'],
+                    ['__proto__', 'polluted'],
+                    ['constructor', 'polluted'],
+                    ['prototype', 'polluted'],
+                ][Symbol.iterator](),
+        })) as unknown as typeof FormData
+
+        fireEvent.submit(form!);
+
+        expect(onSubmitValues).toHaveBeenCalled()
+        const values = onSubmitValues.mock.calls[0][0]
+
+        expect(values.normal).toBe('value')
+
+        // Ensure __proto__ was not actually set on the object
+        expect(Object.prototype.hasOwnProperty.call(values, '__proto__')).toBe(false)
+        expect(Object.prototype.hasOwnProperty.call(values, 'constructor')).toBe(false)
+        expect(Object.prototype.hasOwnProperty.call(values, 'prototype')).toBe(false)
+
+        // Restore original FormData
+        window.FormData = originalFormData;
+    })
+})

--- a/lib/components/Form/security.test.tsx
+++ b/lib/components/Form/security.test.tsx
@@ -2,7 +2,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, fireEvent } from '@testing-library/react'
 import { Form } from './index'
-import React from 'react'
 
 describe('Form Security', () => {
     it('should ignore dangerous keys to prevent prototype pollution', () => {


### PR DESCRIPTION
This PR fixes a high-priority prototype pollution vulnerability in the `Form` component.

### 🚨 Severity: HIGH

### 💡 Vulnerability:
The `Form` component collected values from `FormData` by spreading them into a result object. An attacker could manipulate the DOM to include inputs with names like `__proto__`, potentially polluting the prototype of the object passed to `onSubmitValues`.

### 🎯 Impact:
Prototype pollution can lead to various issues, from denial of service to remote code execution, depending on how the polluted object is used later in the application.

### 🔧 Fix:
- Implemented a check to skip dangerous keys: `__proto__`, `constructor`, and `prototype`.
- Refactored the loop to use direct assignment for better performance and security.

### ✅ Verification:
- Added `lib/components/Form/security.test.tsx` which mocks `FormData` to ensure dangerous keys are filtered.
- Ran the full test suite (`pnpm test`), and all 175 tests passed.
- Verified with `pnpm lint`.


---
*PR created automatically by Jules for task [16149295714479501493](https://jules.google.com/task/16149295714479501493) started by @galiprandi*