### PR TITLE
⚡ Spark: Add pascalCase to valueTransforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Custom input component supporting transformations, debounce, datalist, and more.
 | Prop                | Type                                | Description                             |
 |---------------------|-------------------------------------|------------------------------------------|
 | `label`             | `string`                            | Optional label                          |
-| `transform`         | `string` (`"camelCase"`, `"kebabCase"`, `"titleCase"`, `"onlyEmail"`...) | Built-in value transforms         |
+| `transform`         | `string` (`"camelCase"`, `"pascalCase"`, `"kebabCase"`, `"titleCase"`, `"onlyEmail"`...) | Built-in value transforms         |
 | `transformFn`       | `(value: string) => string`         | Custom value transform                   |
 | `onChangeValue`     | `(value: string) => void`           | Fires on value change                    |
 | `onChangeDebounce`  | `(value: string) => void`           | Fires after debounce                     |

--- a/lib/components/Input/index.tsx
+++ b/lib/components/Input/index.tsx
@@ -27,7 +27,7 @@ import { valueTransforms } from '../../utilities/strings'
  *     onChangeValue={handleChangeValue}
  *     onChangeDebounce={handleChangeDebounce}
  *     debounceDelay={300}
- *     transform="uppercase"
+ *     transform="pascalCase"
  *     className="input-class"
  *     datalist={['john.doe', 'jane.doe', 'john.smith']}
  * />;

--- a/lib/utilities/strings.test.ts
+++ b/lib/utilities/strings.test.ts
@@ -28,6 +28,13 @@ describe('valueTransforms', () => {
         expect(valueTransforms('hello_world', 'camelCase')).toBe('helloWorld')
     })
 
+    it('should transform to pascal case', () => {
+        expect(valueTransforms('hello world', 'pascalCase')).toBe('HelloWorld')
+        expect(valueTransforms('hello-world', 'pascalCase')).toBe('HelloWorld')
+        expect(valueTransforms('hello_world', 'pascalCase')).toBe('HelloWorld')
+        expect(valueTransforms('helloWorld', 'pascalCase')).toBe('HelloWorld')
+    })
+
     it('should transform to kebab case', () => {
         expect(valueTransforms('hello world', 'kebabCase')).toBe('hello-world')
         expect(valueTransforms('helloWorld', 'kebabCase')).toBe('hello-world')

--- a/lib/utilities/strings.ts
+++ b/lib/utilities/strings.ts
@@ -15,6 +15,9 @@
  *
  * const title = valueTransforms('hello world', 'titleCase');
  * console.log(title); // "Hello World"
+ *
+ * const pascal = valueTransforms('hello world', 'pascalCase');
+ * console.log(pascal); // "HelloWorld"
  * ```
  */
 export const valueTransforms = (
@@ -26,6 +29,7 @@ export const valueTransforms = (
     | "titleCase"
     | "snakeCase"
     | "camelCase"
+    | "pascalCase"
     | "kebabCase"
     | "onlyNumbers"
     | "onlyLetters"
@@ -50,6 +54,12 @@ export const valueTransforms = (
         .replace(/(?:^\w|[A-Z]|\b\w)/g, (word, index) =>
           index === 0 ? word.toLowerCase() : word.toUpperCase(),
         )
+        .replace(/\s+/g, "");
+    case "pascalCase":
+      return value
+        .replace(/([a-z])([A-Z])/g, "$1 $2")
+        .replace(/[_-]/g, " ")
+        .replace(/(?:^\w|[A-Z]|\b\w)/g, (word) => word.toUpperCase())
         .replace(/\s+/g, "");
     case "kebabCase":
       return value


### PR DESCRIPTION
💡 **What:** Added 'pascalCase' transformation to 'valueTransforms' utility.
🎯 **Why:** To provide a convenient way to transform strings into PascalCase, a common requirement that was missing from the library's string utilities.
📦 **What it adds:** New 'pascalCase' option in 'valueTransforms' and 'Input' component's 'transform' prop.
🚀 **How to use:** `valueTransforms('hello world', 'pascalCase')` -> "HelloWorld" or `<Input transform="pascalCase" ... />`.
♻️ **Deps Free:** Uses only built-in JavaScript/TypeScript functionality.
🎨 **Harmony:** Follows the existing implementation pattern of 'camelCase' and 'snakeCase' in the same utility.

---
*PR created automatically by Jules for task [2132151502639184732](https://jules.google.com/task/2132151502639184732) started by @galiprandi*