### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DateTime crash on invalid dates

### DIFF
--- a/.axioma/sentinel.md
+++ b/.axioma/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `Form` component was vulnerable to prototype pollution when collecting values from `FormData`.
 **Learning:** Blindly spreading `FormData` entries into an object allows an attacker to inject properties like `__proto__`, `constructor`, or `prototype`, which can lead to prototype pollution.
 **Prevention:** Always validate or filter keys from untrusted input before assigning them to objects. Use direct assignment or `Object.create(null)` for result objects. Note that 'happy-dom' test environment crashes if an HTML input has a 'name' attribute equal to these reserved keys, so mocking 'FormData' is preferred for testing.
+
+## 2025-05-15 - Unhandled Invalid Date in DateTime Component
+**Vulnerability:** The `DateTime` component could crash (RangeError: Invalid time value) if an invalid date string was provided via props or input, as it called `.toISOString()` without validation.
+**Learning:** React state updates or prop changes can trigger effects that perform operations on data (like `new Date()`) that might fail. Unhandled exceptions in `useEffect` can crash the entire React application.
+**Prevention:** Always validate data before calling methods that can throw, especially when dealing with external input or date parsing.

--- a/lib/components/DateTime/index.tsx
+++ b/lib/components/DateTime/index.tsx
@@ -37,7 +37,10 @@ export const DateTime = (props: DateTimeProps): JSX.Element => {
 
     useEffect(() => {
         if (!isoDateTime || !onChangeISOValue) return
-        onChangeISOValue(new Date(isoDateTime).toISOString())
+        const date = new Date(isoDateTime)
+        if (!isNaN(date.getTime())) {
+            onChangeISOValue(date.toISOString())
+        }
     }, [isoDateTime, onChangeISOValue])
 
     return (

--- a/lib/components/DateTime/security.test.tsx
+++ b/lib/components/DateTime/security.test.tsx
@@ -1,0 +1,48 @@
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { DateTime } from './index'
+
+describe('DateTime Security', () => {
+    it('should not crash if invalid date is provided via props', () => {
+        const onChangeISOValue = vi.fn()
+        render(
+            <DateTime isoValue="invalid-date" onChangeISOValue={onChangeISOValue} />
+        )
+
+        expect(onChangeISOValue).not.toHaveBeenCalled()
+    })
+
+    it('should not crash if invalid date is provided via user input', () => {
+        const onChangeISOValue = vi.fn()
+        const { container } = render(
+            <DateTime isoValue="2024-05-14T13:00:00.000Z" onChangeISOValue={onChangeISOValue} />
+        )
+
+        // Clear the initial call from mount
+        onChangeISOValue.mockClear()
+
+        const input = container.querySelector('input')
+        fireEvent.change(input!, { target: { value: 'not-a-date' } })
+
+        // Should NOT call onChangeISOValue with an invalid date
+        expect(onChangeISOValue).not.toHaveBeenCalled()
+    })
+
+    it('should still work for valid dates', () => {
+        const onChangeISOValue = vi.fn()
+        const { container } = render(
+            <DateTime isoValue="2024-05-14T13:00:00.000Z" onChangeISOValue={onChangeISOValue} />
+        )
+
+        onChangeISOValue.mockClear()
+
+        const input = container.querySelector('input')
+        // datetime-local input expects YYYY-MM-DDTHH:mm
+        fireEvent.change(input!, { target: { value: '2024-05-15T14:00' } })
+
+        expect(onChangeISOValue).toHaveBeenCalled()
+        const lastCall = onChangeISOValue.mock.calls[0][0]
+        expect(new Date(lastCall).toISOString()).toBeDefined()
+    })
+})


### PR DESCRIPTION
The DateTime component was vulnerable to a client-side crash (RangeError) when provided with an invalid date. This PR adds input validation to prevent the crash and includes security tests.

---
*PR created automatically by Jules for task [1226757416260037072](https://jules.google.com/task/1226757416260037072) started by @galiprandi*