### PR TITLE
⚡ Spark: add toggle method to useList

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -3,5 +3,5 @@
 **Pattern:** Export a transform utility with a union type for its options, and use `Parameters<typeof fn>[index]` to type props in components that consume it.
 
 ## 2025-05-20 - [Unified Comparison Pattern in useList]
-**Learning:** Implementing a helper like `getValueToCompare` allows list operations (add, remove, update, toggle) to seamlessly handle both primitive values and complex objects through an optional key parameter, maintaining a consistent and predictable API.
-**Pattern:** Use an internal helper to resolve comparison values (e.g., `(item[key] ?? item)`) in hooks that manage collections to support both simple and keyed data structures.
+**Learning:** Leveraging the internal `getValueToCompare` helper allows new list operations like `toggle` to seamlessly handle both primitive values and complex objects through an optional key parameter, maintaining consistency with existing operations like `removeBy` or `findItemsBy`.
+**Pattern:** Follow the repository's existing internal patterns for value comparison to ensure new features harmonize with the established API and behavior.

--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -1,3 +1,7 @@
 ## 2025-05-14 - [Centralized String Transforms]
 **Learning:** Using a centralized utility for string transformations (`valueTransforms`) and then leveraging TypeScript's `Parameters<typeof valueTransforms>[1]` in UI components (like `Input`) ensures that new transformations are automatically available and type-safe across the entire library.
 **Pattern:** Export a transform utility with a union type for its options, and use `Parameters<typeof fn>[index]` to type props in components that consume it.
+
+## 2025-05-20 - [Unified Comparison Pattern in useList]
+**Learning:** Implementing a helper like `getValueToCompare` allows list operations (add, remove, update, toggle) to seamlessly handle both primitive values and complex objects through an optional key parameter, maintaining a consistent and predictable API.
+**Pattern:** Use an internal helper to resolve comparison values (e.g., `(item[key] ?? item)`) in hooks that manage collections to support both simple and keyed data structures.

--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ An object containing the current array state (`list`) and helper functions to mo
 | `findItemBy`     | `(key: string \| undefined \| null, value: any) => T \| undefined` | Finds and returns the **first** item where `item[key]` strictly equals `value`. If `key` is `undefined` or `null`, finds the first item where `item` strictly equals `value`. Does not modify the list. Returns `undefined` if not found. |
 | `findItemsBy`    | `(key: string \| undefined \| null, value: any) => T[]`       | Finds and returns **all** items where `item[key]` strictly equals `value`. If `key` is `undefined` or `null`, finds all items where `item` strictly equals `value`. Does not modify the list. Returns an empty array if no matches are found. |
 | `count`          | `(predicate?: (item: T) => boolean) => number`              | Returns the total number of items in the list, or the count of items matching an optional `predicate`. Does not modify the list.       |
+| `toggle`         | `(item: T, key?: string \| undefined \| null) => void`      | Adds an item if it's not present, or removes it if it is, based on an optional key or reference comparison. |
 
 ***
 

--- a/lib/hooks/useList.test.ts
+++ b/lib/hooks/useList.test.ts
@@ -724,4 +724,61 @@ describe('useList', () => {
             expect(result.current.count((item) => item.done)).toBe(0)
         })
     })
+
+    describe('toggle', () => {
+        it('should add a primitive item if it is not in the list', () => {
+            const { result } = renderHook(() => useList<string>(['a', 'b']))
+            act(() => {
+                result.current.toggle('c')
+            })
+            expect(result.current.list).toEqual(['a', 'b', 'c'])
+        })
+
+        it('should remove a primitive item if it is in the list', () => {
+            const { result } = renderHook(() => useList<string>(['a', 'b', 'c']))
+            act(() => {
+                result.current.toggle('b')
+            })
+            expect(result.current.list).toEqual(['a', 'c'])
+        })
+
+        it('should add an object if it is not in the list (by reference)', () => {
+            const item1 = { id: 1, name: 'a' }
+            const item2 = { id: 2, name: 'b' }
+            const { result } = renderHook(() => useList([item1]))
+            act(() => {
+                result.current.toggle(item2)
+            })
+            expect(result.current.list).toEqual([item1, item2])
+        })
+
+        it('should remove an object if it is in the list (by reference)', () => {
+            const item1 = { id: 1, name: 'a' }
+            const item2 = { id: 2, name: 'b' }
+            const { result } = renderHook(() => useList([item1, item2]))
+            act(() => {
+                result.current.toggle(item2)
+            })
+            expect(result.current.list).toEqual([item1])
+        })
+
+        it('should add an object if it is not in the list (by key)', () => {
+            const item1 = { id: 1, name: 'a' }
+            const { result } = renderHook(() => useList([item1]))
+            act(() => {
+                result.current.toggle({ id: 2, name: 'other' }, 'id')
+            })
+            expect(result.current.list).toEqual([item1, { id: 2, name: 'other' }])
+        })
+
+        it('should remove an object if it is in the list (by key)', () => {
+            const item1 = { id: 1, name: 'a' }
+            const item2 = { id: 2, name: 'b' }
+            const { result } = renderHook(() => useList([item1, item2]))
+            act(() => {
+                result.current.toggle({ id: 2, name: 'anything' }, 'id')
+            })
+            expect(result.current.list).toEqual([item1])
+        })
+    })
 })

--- a/lib/hooks/useList.tsx
+++ b/lib/hooks/useList.tsx
@@ -213,6 +213,22 @@ export function useList<T>(initialList: T[] = []): UseListReturn<T> {
         [list],
     )
 
+    const toggle = useCallback(
+        (item: T, key?: string | undefined | null) => {
+            const value = getValueToCompare(item, key)
+            const index = list.findIndex(
+                (i) => getValueToCompare(i, key) === value,
+            )
+
+            if (index === -1) {
+                addItem(item)
+            } else {
+                removeByIdx(index)
+            }
+        },
+        [list, addItem, removeByIdx],
+    )
+
     return {
         list,
         addItem,
@@ -230,6 +246,7 @@ export function useList<T>(initialList: T[] = []): UseListReturn<T> {
         findItemBy,
         findItemsBy,
         count,
+        toggle,
     }
 }
 
@@ -278,4 +295,6 @@ interface UseListReturn<T> {
     findItemsBy: (key: string | undefined | null, value: any) => T[]
     /** Returns the total number of items, or count of items matching a predicate. */
     count: (predicate?: (item: T) => boolean) => number
+    /** Adds an item if it's not present, or removes it if it is, based on an optional key or reference comparison. */
+    toggle: (item: T, key?: string | undefined | null) => void
 }


### PR DESCRIPTION
💡 **What:** Added a `toggle` method to the `useList` hook.
🎯 **Why:** To provide a convenient way to add an item if it's not present or remove it if it is, which is a common requirement when managing selection lists or tags.
📦 **What it adds:** A new `toggle` method in `UseListReturn<T>`: `(item: T, key?: string | undefined | null) => void`.
🚀 **How to use:**
```tsx
const { list, toggle } = useList(['apple', 'banana']);
toggle('cherry'); // Adds 'cherry'
toggle('apple'); // Removes 'apple'

// With objects and a key
const { list: users, toggle: toggleUser } = useList([{ id: 1, name: 'Alice' }]);
toggleUser({ id: 2, name: 'Bob' }, 'id'); // Adds Bob
toggleUser({ id: 1 }, 'id'); // Removes Alice
```
♻️ **Deps Free:** Confirmed, uses only existing React hooks and internal helpers.
🎨 **Harmony:** Fits existing `useList` patterns and leverages the internal `getValueToCompare` helper for consistent behavior.

---
*PR created automatically by Jules for task [14763748211454590048](https://jules.google.com/task/14763748211454590048) started by @galiprandi*