### PR TITLE
⚡ Spark: Add move method to useList hook

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -9,3 +9,7 @@
 ## 2025-05-24 - [Stable Function References in useList]
 **Learning:** Using a stable `setListCallback` wrapper for the state setter in complex hooks like `useList` ensures that all returned API methods have stable references, preventing unnecessary re-renders in consuming components when these methods are passed as props.
 **Pattern:** Wrap the state setter in a `useCallback` (`setListCallback`) and use it as the dependency for all other hook methods.
+
+## 2025-05-25 - [Full Circle Features: Implementation to Documentation]
+**Learning:** A micro-feature is only complete when it is reflected in the `README.md`. Always update the component/hook documentation table when adding new public API methods to ensure users can discover and use the new functionality immediately.
+**Pattern:** Every change to `UseListReturn` or similar public interfaces must be accompanied by a corresponding update in the project's primary `README.md`.

--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -5,3 +5,7 @@
 ## 2025-05-20 - [Unified Comparison Pattern in useList]
 **Learning:** Leveraging the internal `getValueToCompare` helper allows new list operations like `toggle` to seamlessly handle both primitive values and complex objects through an optional key parameter, maintaining consistency with existing operations like `removeBy` or `findItemsBy`.
 **Pattern:** Follow the repository's existing internal patterns for value comparison to ensure new features harmonize with the established API and behavior.
+
+## 2025-05-24 - [Stable Function References in useList]
+**Learning:** Using a stable `setListCallback` wrapper for the state setter in complex hooks like `useList` ensures that all returned API methods have stable references, preventing unnecessary re-renders in consuming components when these methods are passed as props.
+**Pattern:** Wrap the state setter in a `useCallback` (`setListCallback`) and use it as the dependency for all other hook methods.

--- a/README.md
+++ b/README.md
@@ -663,6 +663,7 @@ An object containing the current array state (`list`) and helper functions to mo
 | `findItemsBy`    | `(key: string \| undefined \| null, value: any) => T[]`       | Finds and returns **all** items where `item[key]` strictly equals `value`. If `key` is `undefined` or `null`, finds all items where `item` strictly equals `value`. Does not modify the list. Returns an empty array if no matches are found. |
 | `count`          | `(predicate?: (item: T) => boolean) => number`              | Returns the total number of items in the list, or the count of items matching an optional `predicate`. Does not modify the list.       |
 | `toggle`         | `(item: T, key?: string \| undefined \| null) => void`      | Adds an item if it's not present, or removes it if it is, based on an optional key or reference comparison. |
+| `move`           | `(fromIndex: number, toIndex: number) => void`              | Moves an item from `fromIndex` to `toIndex` immutably. If indices are out of bounds or identical, the list remains unchanged. |
 
 ***
 

--- a/lib/hooks/useList.test.ts
+++ b/lib/hooks/useList.test.ts
@@ -781,4 +781,61 @@ describe('useList', () => {
             expect(result.current.list).toEqual([item1])
         })
     })
+
+    describe('move', () => {
+        it('should move an item forward in the list', () => {
+            const { result } = renderHook(() => useList(['a', 'b', 'c']))
+            act(() => {
+                result.current.move(0, 1)
+            })
+            expect(result.current.list).toEqual(['b', 'a', 'c'])
+        })
+
+        it('should move an item backward in the list', () => {
+            const { result } = renderHook(() => useList(['a', 'b', 'c']))
+            act(() => {
+                result.current.move(2, 0)
+            })
+            expect(result.current.list).toEqual(['c', 'a', 'b'])
+        })
+
+        it('should move an item to the same position without change', () => {
+            const initialList = ['a', 'b', 'c']
+            const { result } = renderHook(() => useList(initialList))
+            const originalList = result.current.list
+            act(() => {
+                result.current.move(1, 1)
+            })
+            expect(result.current.list).toEqual(initialList)
+            expect(result.current.list).toBe(originalList)
+        })
+
+        it('should do nothing if fromIndex is out of bounds', () => {
+            const initialList = ['a', 'b', 'c']
+            const { result } = renderHook(() => useList(initialList))
+            const originalList = result.current.list
+            act(() => {
+                result.current.move(-1, 1)
+            })
+            expect(result.current.list).toBe(originalList)
+            act(() => {
+                result.current.move(3, 1)
+            })
+            expect(result.current.list).toBe(originalList)
+        })
+
+        it('should do nothing if toIndex is out of bounds', () => {
+            const initialList = ['a', 'b', 'c']
+            const { result } = renderHook(() => useList(initialList))
+            const originalList = result.current.list
+            act(() => {
+                result.current.move(1, -1)
+            })
+            expect(result.current.list).toBe(originalList)
+            act(() => {
+                result.current.move(1, 3)
+            })
+            expect(result.current.list).toBe(originalList)
+        })
+    })
 })

--- a/lib/hooks/useList.tsx
+++ b/lib/hooks/useList.tsx
@@ -229,6 +229,28 @@ export function useList<T>(initialList: T[] = []): UseListReturn<T> {
         [list, addItem, removeByIdx],
     )
 
+    const move = useCallback(
+        (fromIndex: number, toIndex: number) => {
+            setListCallback((currentList) => {
+                if (
+                    fromIndex < 0 ||
+                    fromIndex >= currentList.length ||
+                    toIndex < 0 ||
+                    toIndex >= currentList.length ||
+                    fromIndex === toIndex
+                ) {
+                    return currentList
+                }
+
+                const newList = [...currentList]
+                const [item] = newList.splice(fromIndex, 1)
+                newList.splice(toIndex, 0, item)
+                return newList
+            })
+        },
+        [setListCallback],
+    )
+
     return {
         list,
         addItem,
@@ -247,6 +269,7 @@ export function useList<T>(initialList: T[] = []): UseListReturn<T> {
         findItemsBy,
         count,
         toggle,
+        move,
     }
 }
 
@@ -297,4 +320,6 @@ interface UseListReturn<T> {
     count: (predicate?: (item: T) => boolean) => number
     /** Adds an item if it's not present, or removes it if it is, based on an optional key or reference comparison. */
     toggle: (item: T, key?: string | undefined | null) => void
+    /** Moves an item from one index to another immutably. */
+    move: (fromIndex: number, toIndex: number) => void
 }


### PR DESCRIPTION
💡 **What:** Added a `move` method to the `useList` hook.
🎯 **Why:** To provide a simple and immutable way to reorder items in a list, which is a common requirement for UI features like manual sorting.
📦 **What it adds:** A new `move(fromIndex: number, toIndex: number)` method to the object returned by `useList`.
🚀 **How to use:**
\`\`\`tsx
const { list, move } = useList(['a', 'b', 'c']);
// Move 'a' to the middle
move(0, 1); // list is now ['b', 'a', 'c']
\`\`\`
♻️ **Deps Free:** Uses only React's `useCallback` and standard array methods.
🎨 **Harmony:** Fits perfectly with existing `useList` methods like `insert`, `removeByIdx`, and `updateByIdx`.

---
*PR created automatically by Jules for task [6980838464187123813](https://jules.google.com/task/6980838464187123813) started by @galiprandi*