### PR TITLE
🛡️ Sentinel: [security improvement] Fix prototype access vulnerability in useList

### DIFF
--- a/.axioma/sentinel.md
+++ b/.axioma/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The `DateTime` component could crash (RangeError: Invalid time value) if an invalid date string was provided via props or input, as it called `.toISOString()` without validation.
 **Learning:** React state updates or prop changes can trigger effects that perform operations on data (like `new Date()`) that might fail. Unhandled exceptions in `useEffect` can crash the entire React application.
 **Prevention:** Always validate data before calling methods that can throw, especially when dealing with external input or date parsing.
+
+## 2024-05-18 - Prototype Access Vulnerability in useList
+**Vulnerability:** The `useList` hook allowed matching items using prototype properties like `constructor` or `__proto__` when a key was provided to helper methods like `removeBy` or `toggle`.
+**Learning:** Functions that dynamically access object properties using a string key from parameters can unintentionally expose internal object state or methods if the key is not validated.
+**Prevention:** Implement a blacklist of restricted keys (e.g., `__proto__`, `constructor`, `prototype`, `toString`) when performing dynamic property access on objects, especially in generic utilities or hooks.

--- a/lib/hooks/useList.security.test.ts
+++ b/lib/hooks/useList.security.test.ts
@@ -1,0 +1,44 @@
+
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react-hooks'
+import { useList } from './useList'
+
+describe('useList Security', () => {
+    it('should not allow matching items via prototype properties like constructor', () => {
+        const initialList = [{ id: 1 }, { id: 2 }]
+        const { result } = renderHook(() => useList(initialList))
+
+        act(() => {
+            // This should NOT remove any item because 'constructor' is a restricted key
+            // Even though item.constructor === Object
+            // @ts-ignore - testing restricted key
+            result.current.removeBy('constructor', Object)
+        })
+
+        expect(result.current.list).toHaveLength(2)
+    })
+
+    it('should not allow matching items via __proto__', () => {
+        const initialList = [{ id: 1 }]
+        const { result } = renderHook(() => useList(initialList))
+
+        act(() => {
+            // @ts-ignore - testing restricted key
+            result.current.removeBy('__proto__', Object.prototype)
+        })
+
+        expect(result.current.list).toHaveLength(1)
+    })
+
+    it('should not allow matching items via toString', () => {
+        const initialList = [{ id: 1 }]
+        const { result } = renderHook(() => useList(initialList))
+
+        act(() => {
+            // @ts-ignore - testing restricted key
+            result.current.removeBy('toString', initialList[0].toString)
+        })
+
+        expect(result.current.list).toHaveLength(1)
+    })
+})

--- a/lib/hooks/useList.tsx
+++ b/lib/hooks/useList.tsx
@@ -1,9 +1,25 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useCallback } from 'react'
 
+const RESTRICTED_KEYS = [
+    '__proto__',
+    'constructor',
+    'prototype',
+    'toString',
+    'valueOf',
+    'toLocaleString',
+    'hasOwnProperty',
+    'isPrototypeOf',
+    'propertyIsEnumerable',
+]
+
 function getValueToCompare<T>(item: T, key: string | undefined | null): any {
     if (key === undefined || key === null) {
         return item
+    }
+
+    if (RESTRICTED_KEYS.includes(key)) {
+        return undefined
     }
     if (typeof item === 'object' && item !== null) {
         return (item as any)[key]


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

💡 Vulnerability: The `useList` hook allowed matching items using internal prototype properties (like `constructor`, `__proto__`, `toString`, etc.) when a key was provided to helper methods such as `removeBy`, `updateBy`, `findItemBy`, or `toggle`.

🎯 Impact: If the key comes from an untrusted source, it could be used to perform operations on items based on their prototype properties rather than their actual data. For example, `removeBy('constructor', Object)` would remove all items that are plain objects.

🔧 Fix: Implemented a `RESTRICTED_KEYS` blacklist in `lib/hooks/useList.tsx` to prevent access to these sensitive properties during item comparison.

✅ Verification: Added `lib/hooks/useList.security.test.ts` which confirms that restricted keys no longer allow matching items. All existing tests pass and the project builds successfully.

---
*PR created automatically by Jules for task [15295141025076144116](https://jules.google.com/task/15295141025076144116) started by @galiprandi*