### PR TITLE
⚡ Spark: Add reload functionality to AsyncBlock

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -13,3 +13,7 @@
 ## 2025-05-25 - [Full Circle Features: Implementation to Documentation]
 **Learning:** A micro-feature is only complete when it is reflected in the `README.md`. Always update the component/hook documentation table when adding new public API methods to ensure users can discover and use the new functionality immediately.
 **Pattern:** Every change to `UseListReturn` or similar public interfaces must be accompanied by a corresponding update in the project's primary `README.md`.
+
+## 2026-05-15 - [Render Prop Reload Pattern]
+**Learning:** Adding a `reload` function as an argument to render props in components that manage async state (`AsyncBlock`) provides a seamless way for users to implement manual refresh or retry logic without increasing component complexity.
+**Pattern:** Implement an internal `tick` state that triggers the core `useEffect` and expose a `reload` callback that increments it via the component's render functions.

--- a/README.md
+++ b/README.md
@@ -98,8 +98,18 @@ Declarative component to render async data with loading, success, and error stat
 <AsyncBlock
   promiseFn={() => fetch(`/api/user`).then(res => res.json())}
   pending={<p>Loading...</p>}
-  success={(data) => <p>Welcome {data.name}</p>}
-  error={(err) => <p>Error: {(err as Error).message}</p>}
+  success={(data, reload) => (
+    <div>
+      <p>Welcome {data.name}</p>
+      <button onClick={reload}>Refresh</button>
+    </div>
+  )}
+  error={(err, reload) => (
+    <div>
+      <p>Error: {(err as Error).message}</p>
+      <button onClick={reload}>Retry</button>
+    </div>
+  )}
   timeOut={5000}
   deps={[userId]}
 />
@@ -110,9 +120,9 @@ Declarative component to render async data with loading, success, and error stat
 | Prop         | Type                                     | Description                             |
 |--------------|------------------------------------------|------------------------------------------|
 | `promiseFn`  | `(signal?: AbortSignal) => Promise<T>`   | Async function returning a Promise       |
-| `pending`    | `ReactNode \| () => ReactNode`           | UI while loading                         |
-| `success`    | `(data: T) => ReactNode`                 | UI on success                            |
-| `error`      | `(err: unknown) => ReactNode`            | UI on error                              |
+| `pending`    | `ReactNode \| (reload: () => void) => ReactNode` | UI while loading                 |
+| `success`    | `(data: T, reload: () => void) => ReactNode` | UI on success                      |
+| `error`      | `(err: unknown, reload: () => void) => ReactNode` | UI on error                    |
 | `timeOut`    | `number`                                 | Optional timeout in ms                   |
 | `deps`       | `any[]`                                  | Dependency list for re-execution         |
 | `onSuccess`  | `(data: T) => void`                      | Optional success callback                |

--- a/lib/components/AsyncBlock/index.test.tsx
+++ b/lib/components/AsyncBlock/index.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { render, cleanup, screen } from '@testing-library/react'
+import { render, cleanup, screen, act } from '@testing-library/react'
 import { AsyncBlock } from './index'
 
 describe('<AsyncBlock />', () => {
@@ -85,5 +85,52 @@ describe('<AsyncBlock />', () => {
 
         unmount()
         // Test should not hang or fail due to cleanup
+    })
+
+    it('should reload the promise when reload is called', async () => {
+        let callCount = 0
+        let resolvePromise: (value: string) => void
+
+        const promiseFn = vi.fn(() => {
+            callCount++
+            return new Promise<string>((resolve) => {
+                resolvePromise = resolve
+            })
+        })
+
+        render(
+            <AsyncBlock
+                promiseFn={promiseFn}
+                pending="Loading"
+                success={(data, reload) => (
+                    <div>
+                        <span>{data}</span>
+                        <button onClick={reload}>Reload</button>
+                    </div>
+                )}
+                error={() => null}
+            />
+        )
+
+        expect(screen.getByText('Loading')).toBeDefined()
+        act(() => {
+            resolvePromise(`Data ${callCount}`)
+        })
+
+        await screen.findByText('Data 1')
+        expect(promiseFn).toHaveBeenCalledTimes(1)
+
+        const button = screen.getByText('Reload')
+        act(() => {
+            button.click()
+        })
+
+        expect(screen.getByText('Loading')).toBeDefined()
+        act(() => {
+            resolvePromise(`Data ${callCount}`)
+        })
+
+        await screen.findByText('Data 2')
+        expect(promiseFn).toHaveBeenCalledTimes(2)
     })
 })

--- a/lib/components/AsyncBlock/index.tsx
+++ b/lib/components/AsyncBlock/index.tsx
@@ -41,7 +41,12 @@ export const AsyncBlock = <T,>({
     )
     const [data, setData] = useState<T | null>(null)
     const [err, setErr] = useState<unknown>(null)
+    const [tick, setTick] = useState(0)
     const isMounted = useRef(true)
+
+    const reload = useCallback(() => {
+        setTick((t) => t + 1)
+    }, [])
 
     const run = useCallback(
         (abortController: AbortController) => {
@@ -105,18 +110,22 @@ export const AsyncBlock = <T,>({
             // This ensures any in-flight requests are canceled when
             // the component unmounts or dependencies change
         }
-    }, deps)
+    }, [...deps, tick])
 
     if (state === 'pending') {
-        return typeof pending === 'function' ? <>{pending()}</> : <>{pending}</>
+        return typeof pending === 'function' ? (
+            <>{pending(reload)}</>
+        ) : (
+            <>{pending}</>
+        )
     }
 
     if (state === 'error') {
-        return <>{error?.(err)}</>
+        return <>{error?.(err, reload)}</>
     }
 
     if (state === 'success' && data !== null) {
-        return <>{success(data)}</>
+        return <>{success(data, reload)}</>
     }
 
     return null
@@ -133,16 +142,19 @@ export interface AsyncBlockProps<T> extends PropsWithChildren {
     promiseFn: (signal?: AbortSignal) => Promise<T>
     /**
      * Element or function to render while the promise is pending.
+     * Optionally receives a reload function to re-run the async operation.
      */
-    pending: ReactNode | (() => ReactNode)
+    pending: ReactNode | ((reload: () => void) => ReactNode)
     /**
      * Function to render if the promise resolves successfully.
+     * Receives the data and a reload function.
      */
-    success: (data: T) => ReactNode
+    success: (data: T, reload: () => void) => ReactNode
     /**
      * Function to render if the promise is rejected or times out.
+     * Receives the error and a reload function.
      */
-    error: (err: unknown) => ReactNode
+    error: (err: unknown, reload: () => void) => ReactNode
     /**
      * Optional timeout in milliseconds before failing the promise.
      */


### PR DESCRIPTION
💡 **What:** Added a `reload` function to the `AsyncBlock` component.

🎯 **Why:** To enable manual re-runs of asynchronous operations, providing a built-in way to implement "Refresh" or "Retry" functionality in the UI.

📦 **What it adds:**
- A `reload: () => void` callback argument to the `success`, `error`, and `pending` (when provided as a function) render props.
- Internal `tick` state management to trigger effect re-execution.

🚀 **How to use:**
\`\`\`tsx
<AsyncBlock
  promiseFn={() => fetchUserData()}
  pending={<p>Loading...</p>}
  success={(data, reload) => (
    <div>
      <p>Welcome {data.name}</p>
      <button onClick={reload}>Refresh Data</button>
    </div>
  )}
  error={(err, reload) => (
    <div>
      <p>Failed to load: {(err as Error).message}</p>
      <button onClick={reload}>Retry</button>
    </div>
  )}
/>
\`\`\`

♻️ **Deps Free:** Uses only React built-in hooks (\`useState\`, \`useCallback\`, \`useEffect\`).

🎨 **Harmony:** Aligns with the existing render prop pattern of the library while adding a common missing feature for async handling.

---
*PR created automatically by Jules for task [6164769758414426559](https://jules.google.com/task/6164769758414426559) started by @galiprandi*