### PR TITLE
✨ Quality: refactor and improve string transformation utilities

### DIFF
--- a/.axioma/quality.md
+++ b/.axioma/quality.md
@@ -9,3 +9,7 @@
 ## 2025-05-15 - [Testing IntersectionObserver and State Updates]
 **Learning:** Testing components that use `IntersectionObserver` in 'happy-dom' requires mocking the global `IntersectionObserver` and manually invoking the callback. Furthermore, any state updates triggered by these callbacks must be wrapped in `act` from `@testing-library/react` to avoid "update not wrapped in act" warnings and ensure the UI reflects the new state before assertions.
 **Action:** Mock `window.IntersectionObserver` and use `act` when simulating intersection changes in tests.
+
+## 2025-05-20 - [Robust String Transformations]
+**Learning:** Common string transformations (camelCase, pascalCase, snakeCase) often fail on "extreme" inputs like all-caps strings or multiple consecutive spaces if they rely on simple regex-based word boundaries. Standardizing input via `.toLowerCase()` and `.trim()` before applying transformation regexes significantly increases utility robustness.
+**Action:** Always normalize casing and whitespace when implementing or updating string transformation utilities to handle inconsistent user input.

--- a/lib/utilities/strings.test.ts
+++ b/lib/utilities/strings.test.ts
@@ -76,12 +76,39 @@ describe('valueTransforms', () => {
 
     it('should handle strings with multiple spaces', () => {
         expect(valueTransforms('hello   world', 'snakeCase')).toBe(
-            'hello___world',
+            'hello_world',
         )
-        expect(valueTransforms('  hello  ', 'capitalize')).toBe('  hello  ')
+        expect(valueTransforms('  hello  ', 'capitalize')).toBe('Hello')
     })
 
     it('should handle multiple words in capitalize (only first char of first word)', () => {
         expect(valueTransforms('hello world', 'capitalize')).toBe('Hello world')
+    })
+
+    it('should lowercase other characters in capitalize', () => {
+        expect(valueTransforms('HELLO', 'capitalize')).toBe('Hello')
+        expect(valueTransforms('hELLO', 'capitalize')).toBe('Hello')
+    })
+
+    it('should handle all-caps in camelCase and pascalCase', () => {
+        expect(valueTransforms('HELLO WORLD', 'camelCase')).toBe('helloWorld')
+        expect(valueTransforms('HELLO WORLD', 'pascalCase')).toBe('HelloWorld')
+    })
+
+    it('should apply sequential transforms from an array', () => {
+        expect(
+            valueTransforms('Hello World 123!', [
+                'toUpperCase',
+                'onlyAlphanumeric',
+            ]),
+        ).toBe('HELLOWORLD123')
+
+        expect(
+            valueTransforms('  Some_Mixed-Value  ', [
+                'onlyLetters',
+                'toLowerCase',
+                'capitalize',
+            ]),
+        ).toBe('Somemixedvalue')
     })
 })

--- a/lib/utilities/strings.ts
+++ b/lib/utilities/strings.ts
@@ -23,35 +23,27 @@
  * console.log(multiple); // "HELLOWORLD123"
  * ```
  */
+
+/**
+ * Available transformation types for strings.
+ */
+export type TransformType =
+  | "toUpperCase"
+  | "toLowerCase"
+  | "capitalize"
+  | "titleCase"
+  | "snakeCase"
+  | "camelCase"
+  | "pascalCase"
+  | "kebabCase"
+  | "onlyNumbers"
+  | "onlyLetters"
+  | "onlyEmail"
+  | "onlyAlphanumeric";
+
 export const valueTransforms = (
   value: string,
-  transform?:
-    | "toUpperCase"
-    | "toLowerCase"
-    | "capitalize"
-    | "titleCase"
-    | "snakeCase"
-    | "camelCase"
-    | "pascalCase"
-    | "kebabCase"
-    | "onlyNumbers"
-    | "onlyLetters"
-    | "onlyEmail"
-    | "onlyAlphanumeric"
-    | Array<
-        | "toUpperCase"
-        | "toLowerCase"
-        | "capitalize"
-        | "titleCase"
-        | "snakeCase"
-        | "camelCase"
-        | "pascalCase"
-        | "kebabCase"
-        | "onlyNumbers"
-        | "onlyLetters"
-        | "onlyEmail"
-        | "onlyAlphanumeric"
-      >
+  transform?: TransformType | TransformType[],
 ): string => {
   const applyTransform = (val: string, t: string): string => {
     switch (t) {
@@ -60,15 +52,16 @@ export const valueTransforms = (
       case "toLowerCase":
         return val.toLowerCase();
       case "capitalize":
-        return val.toLowerCase().charAt(0).toUpperCase() + val.slice(1);
+        return val.trim().charAt(0).toUpperCase() + val.trim().slice(1).toLowerCase();
       case "titleCase":
         return val.toLowerCase().replace(/\b\w/g, (ch) => ch.toUpperCase());
       case "snakeCase":
-        return val.toLowerCase().replace(/\s/g, "_");
+        return val.toLowerCase().trim().replace(/\s+/g, "_");
       case "camelCase":
         return val
           .replace(/([a-z])([A-Z])/g, "$1 $2")
           .replace(/[_-]/g, " ")
+          .toLowerCase()
           .replace(/(?:^\w|[A-Z]|\b\w)/g, (word, index) =>
             index === 0 ? word.toLowerCase() : word.toUpperCase(),
           )
@@ -77,6 +70,7 @@ export const valueTransforms = (
         return val
           .replace(/([a-z])([A-Z])/g, "$1 $2")
           .replace(/[_-]/g, " ")
+          .toLowerCase()
           .replace(/(?:^\w|[A-Z]|\b\w)/g, (word) => word.toUpperCase())
           .replace(/\s+/g, "");
       case "kebabCase":


### PR DESCRIPTION
💡 What:
- Extracted `TransformType` type alias for better maintainability and reusability.
- Improved `capitalize` to trim input and lowercase trailing characters.
- Improved `snakeCase` to collapse multiple spaces and trim input.
- Improved `camelCase` and `pascalCase` to handle all-caps inputs by normalizing casing first.
- Added comprehensive tests for sequential transforms and edge cases.

🎯 Why:
- Previous implementations failed on inconsistent inputs like "HELLO WORLD" or multiple spaces.
- Inline type definitions were repetitive and harder to maintain.

📊 Impact:
- More robust string utilities that handle diverse real-world inputs correctly.
- Better developer experience with exported types and clear JSDoc examples.
- Increased test coverage for the utility library.

✅ Verification:
- All 321 tests passed (run via `pnpm test`).
- Linting verified via `pnpm lint`.

---
*PR created automatically by Jules for task [4322548307127071202](https://jules.google.com/task/4322548307127071202) started by @galiprandi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * String transformation utilities now properly handle edge cases including excess whitespace, leading/trailing spaces, and all-caps input strings.
  * Enhanced input normalization ensures consistent and predictable behavior across diverse text formatting scenarios.

* **Documentation**
  * Added quality guidelines documenting robustness requirements for string transformation utilities, including guidance for handling extreme inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galiprandi/react-tools/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->