### PR TITLE
⚡ Spark: add swap method to useList hook

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -1,19 +1,29 @@
 ## 2025-05-14 - [Centralized String Transforms]
+
 **Learning:** Using a centralized utility for string transformations (`valueTransforms`) and then leveraging TypeScript's `Parameters<typeof valueTransforms>[1]` in UI components (like `Input`) ensures that new transformations are automatically available and type-safe across the entire library.
 **Pattern:** Export a transform utility with a union type for its options, and use `Parameters<typeof fn>[index]` to type props in components that consume it.
 
 ## 2025-05-20 - [Unified Comparison Pattern in useList]
+
 **Learning:** Leveraging the internal `getValueToCompare` helper allows new list operations like `toggle` to seamlessly handle both primitive values and complex objects through an optional key parameter, maintaining consistency with existing operations like `removeBy` or `findItemsBy`.
 **Pattern:** Follow the repository's existing internal patterns for value comparison to ensure new features harmonize with the established API and behavior.
 
 ## 2025-05-24 - [Stable Function References in useList]
+
 **Learning:** Using a stable `setListCallback` wrapper for the state setter in complex hooks like `useList` ensures that all returned API methods have stable references, preventing unnecessary re-renders in consuming components when these methods are passed as props.
 **Pattern:** Wrap the state setter in a `useCallback` (`setListCallback`) and use it as the dependency for all other hook methods.
 
 ## 2025-05-25 - [Full Circle Features: Implementation to Documentation]
+
 **Learning:** A micro-feature is only complete when it is reflected in the `README.md`. Always update the component/hook documentation table when adding new public API methods to ensure users can discover and use the new functionality immediately.
 **Pattern:** Every change to `UseListReturn` or similar public interfaces must be accompanied by a corresponding update in the project's primary `README.md`.
 
 ## 2026-05-15 - [Render Prop Reload Pattern]
+
 **Learning:** Adding a `reload` function as an argument to render props in components that manage async state (`AsyncBlock`) provides a seamless way for users to implement manual refresh or retry logic without increasing component complexity.
 **Pattern:** Implement an internal `tick` state that triggers the core `useEffect` and expose a `reload` callback that increments it via the component's render functions.
+
+## 2026-05-18 - [Optimized State Updates in useList]
+
+**Learning:** When implementing list operations like `swap` that may be called with redundant parameters (e.g., identical indices or out-of-bounds), implementing early-return guard clauses that return the original state reference prevents unnecessary re-renders and improves performance.
+**Pattern:** Always check for redundant or invalid operations at the beginning of state updater functions and return the current state to leverage React's `Object.is` optimization.

--- a/README.md
+++ b/README.md
@@ -18,14 +18,13 @@
   </a>
 </p>
 
-
 ## 🧠 Overview
 
 **@galiprandi/react-tools** is a lightweight, dependency-free utility library for React. It provides reusable components and hooks to simplify development and improve accessibility — no configuration needed.
 
 👉 [Live Playground](https://stackblitz.com/edit/ga-react-tools?file=index.html)
 
-***
+---
 
 ## 🚀 Installation
 
@@ -47,52 +46,51 @@ npx skills add https://github.com/galiprandi/skills --skill react-tools
 
 This provides comprehensive guidance for using @galiprandi/react-tools with AI agents.
 
-***
+---
 
 ## ✨ What's New
 
 **AI Hooks** - New hooks for browser-native AI features using Chrome's AI API:
 
-- **useAI** - Check and manage availability of browser's AI APIs
-- **useAISummarize** - Generate text summaries with streaming support
-- **useLanguageDetection** - Detect language from text with confidence scores
-- **useTranslator** - Translate text between languages with streaming support
-- **useAIPrompt** - Generate AI responses using Chrome's Prompt API (Gemini Nano)
-- **useAIWrite** - Generate written content with customizable tone and format
-- **useAIRewriter** - Rewrite and restructure text with customizable tone, format, and length
-- **useAIProofreader** - Check grammar and spelling with highlighted corrections
+-   **useAI** - Check and manage availability of browser's AI APIs
+-   **useAISummarize** - Generate text summaries with streaming support
+-   **useLanguageDetection** - Detect language from text with confidence scores
+-   **useTranslator** - Translate text between languages with streaming support
+-   **useAIPrompt** - Generate AI responses using Chrome's Prompt API (Gemini Nano)
+-   **useAIWrite** - Generate written content with customizable tone and format
+-   **useAIRewriter** - Rewrite and restructure text with customizable tone, format, and length
+-   **useAIProofreader** - Check grammar and spelling with highlighted corrections
 
-***
+---
 
 ## 📚 Table of Contents
 
-* [Overview](#overview)
-* [Installation](#installation)
-* [Components](#components)
-  * [AsyncBlock](#asyncblock)
-  * [Form](#form)
-  * [Input](#input)
-  * [DateTime](#datetime)
-  * [Dialog](#dialog)
-  * [Observer](#observer)
-  * [LazyRender](#lazyrender)
-* [Hooks](#hooks)
-  * [useAI](#useai)
-  * [useAISummarize](#useaisummarize)
-  * [useLanguageDetection](#uselanguagedetection)
-  * [useTranslator](#usetranslator)
-  * [useAIPrompt](#useaiprompt)
-  * [useAIWrite](#useaiwrite)
-  * [useAIRewriter](#useairewriter)
-  * [useAIProofreader](#useaiproofreader)
-  * [useDebounce](#usedebounce)
-  * [useThrottle](#usethrottle)
-  * [useTimer](#usetimer)
-  * [useList](#uselist)
-* [Accessibility & Performance](#accessibility--performance)
-* [FAQ](#faq)
-* [License](#license)
-
+-   [Overview](#overview)
+-   [Installation](#installation)
+-   [Components](#components)
+    -   [AsyncBlock](#asyncblock)
+    -   [Form](#form)
+    -   [Input](#input)
+    -   [DateTime](#datetime)
+    -   [Dialog](#dialog)
+    -   [Observer](#observer)
+    -   [LazyRender](#lazyrender)
+-   [Hooks](#hooks)
+    -   [useAI](#useai)
+    -   [useAISummarize](#useaisummarize)
+    -   [useLanguageDetection](#uselanguagedetection)
+    -   [useTranslator](#usetranslator)
+    -   [useAIPrompt](#useaiprompt)
+    -   [useAIWrite](#useaiwrite)
+    -   [useAIRewriter](#useairewriter)
+    -   [useAIProofreader](#useaiproofreader)
+    -   [useDebounce](#usedebounce)
+    -   [useThrottle](#usethrottle)
+    -   [useTimer](#usetimer)
+    -   [useList](#uselist)
+-   [Accessibility & Performance](#accessibility--performance)
+-   [FAQ](#faq)
+-   [License](#license)
 
 ## 📦 Components
 
@@ -105,39 +103,39 @@ Declarative component to render async data with loading, success, and error stat
 
 ```tsx
 <AsyncBlock
-  promiseFn={() => fetch(`/api/user`).then(res => res.json())}
-  pending={<p>Loading...</p>}
-  success={(data, reload) => (
-    <div>
-      <p>Welcome {data.name}</p>
-      <button onClick={reload}>Refresh</button>
-    </div>
-  )}
-  error={(err, reload) => (
-    <div>
-      <p>Error: {(err as Error).message}</p>
-      <button onClick={reload}>Retry</button>
-    </div>
-  )}
-  timeOut={5000}
-  deps={[userId]}
+    promiseFn={() => fetch(`/api/user`).then((res) => res.json())}
+    pending={<p>Loading...</p>}
+    success={(data, reload) => (
+        <div>
+            <p>Welcome {data.name}</p>
+            <button onClick={reload}>Refresh</button>
+        </div>
+    )}
+    error={(err, reload) => (
+        <div>
+            <p>Error: {(err as Error).message}</p>
+            <button onClick={reload}>Retry</button>
+        </div>
+    )}
+    timeOut={5000}
+    deps={[userId]}
 />
 ```
 
 **Props**
 
-| Prop         | Type                                     | Description                             |
-|--------------|------------------------------------------|------------------------------------------|
-| `promiseFn`  | `(signal?: AbortSignal) => Promise<T>`   | Async function returning a Promise       |
-| `pending`    | `ReactNode \| (reload: () => void) => ReactNode` | UI while loading                 |
-| `success`    | `(data: T, reload: () => void) => ReactNode` | UI on success                      |
-| `error`      | `(err: unknown, reload: () => void) => ReactNode` | UI on error                    |
-| `timeOut`    | `number`                                 | Optional timeout in ms                   |
-| `deps`       | `any[]`                                  | Dependency list for re-execution         |
-| `onSuccess`  | `(data: T) => void`                      | Optional success callback                |
-| `onError`    | `(err: unknown) => void`                 | Optional error callback                  |
+| Prop        | Type                                              | Description                        |
+| ----------- | ------------------------------------------------- | ---------------------------------- |
+| `promiseFn` | `(signal?: AbortSignal) => Promise<T>`            | Async function returning a Promise |
+| `pending`   | `ReactNode \| (reload: () => void) => ReactNode`  | UI while loading                   |
+| `success`   | `(data: T, reload: () => void) => ReactNode`      | UI on success                      |
+| `error`     | `(err: unknown, reload: () => void) => ReactNode` | UI on error                        |
+| `timeOut`   | `number`                                          | Optional timeout in ms             |
+| `deps`      | `any[]`                                           | Dependency list for re-execution   |
+| `onSuccess` | `(data: T) => void`                               | Optional success callback          |
+| `onError`   | `(err: unknown) => void`                          | Optional error callback            |
 
-***
+---
 
 ### Form
 
@@ -148,19 +146,19 @@ Enhanced `<form>` element that automatically gathers and returns values on submi
 
 ```tsx
 <Form<{ username: string }> onSubmitValues={console.log} filterEmptyValues>
-  <Input name="username" label="Username" />
-  <button type="submit">Submit</button>
+    <Input name="username" label="Username" />
+    <button type="submit">Submit</button>
 </Form>
 ```
 
 **Props**
 
-| Prop               | Type                           | Description                                 |
-|--------------------|--------------------------------|---------------------------------------------|
-| `onSubmitValues`   | `(values: T) => void`          | Handles form submission with collected values |
-| `filterEmptyValues`| `boolean` *(default: false)*   | Remove empty fields before submission        |
+| Prop                | Type                         | Description                                   |
+| ------------------- | ---------------------------- | --------------------------------------------- |
+| `onSubmitValues`    | `(values: T) => void`        | Handles form submission with collected values |
+| `filterEmptyValues` | `boolean` _(default: false)_ | Remove empty fields before submission         |
 
-***
+---
 
 ### Input
 
@@ -189,17 +187,17 @@ Custom input component supporting transformations, debounce, datalist, and more.
 
 **Props**
 
-| Prop                | Type                                | Description                             |
-|---------------------|-------------------------------------|------------------------------------------|
-| `label`             | `string`                            | Optional label                          |
-| `transform`         | `string \| string[]` (`"camelCase"`, `"pascalCase"`, `"kebabCase"`, `"titleCase"`, `"onlyEmail"`...) | Built-in value transforms (single or array for sequential application)         |
-| `transformFn`       | `(value: string) => string`         | Custom value transform                   |
-| `onChangeValue`     | `(value: string) => void`           | Fires on value change                    |
-| `onChangeDebounce`  | `(value: string) => void`           | Fires after debounce                     |
-| `debounceDelay`     | `number`                            | Delay in milliseconds                    |
-| `datalist`          | `string[]`                          | List of autocomplete suggestions         |
+| Prop               | Type                                                                                                 | Description                                                            |
+| ------------------ | ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `label`            | `string`                                                                                             | Optional label                                                         |
+| `transform`        | `string \| string[]` (`"camelCase"`, `"pascalCase"`, `"kebabCase"`, `"titleCase"`, `"onlyEmail"`...) | Built-in value transforms (single or array for sequential application) |
+| `transformFn`      | `(value: string) => string`                                                                          | Custom value transform                                                 |
+| `onChangeValue`    | `(value: string) => void`                                                                            | Fires on value change                                                  |
+| `onChangeDebounce` | `(value: string) => void`                                                                            | Fires after debounce                                                   |
+| `debounceDelay`    | `number`                                                                                             | Delay in milliseconds                                                  |
+| `datalist`         | `string[]`                                                                                           | List of autocomplete suggestions                                       |
 
-***
+---
 
 ### DateTime
 
@@ -209,22 +207,18 @@ A wrapper around `<input type="datetime-local" />` that handles ISO string conve
 **Example**
 
 ```tsx
-<DateTime
-  label="Appointment"
-  isoValue={value}
-  onChangeISOValue={setValue}
-/>
+<DateTime label="Appointment" isoValue={value} onChangeISOValue={setValue} />
 ```
 
 **Props**
 
-| Prop                | Type                              | Description                             |
-|---------------------|-----------------------------------|------------------------------------------|
-| `isoValue`          | `string`                          | ISO 8601 datetime value                 |
-| `onChangeISOValue`  | `(iso: string) => void`           | Callback with ISO string                |
-| `...InputProps`     | All `<Input />` props             | Inherits all Input behavior             |
+| Prop               | Type                    | Description                 |
+| ------------------ | ----------------------- | --------------------------- |
+| `isoValue`         | `string`                | ISO 8601 datetime value     |
+| `onChangeISOValue` | `(iso: string) => void` | Callback with ISO string    |
+| `...InputProps`    | All `<Input />` props   | Inherits all Input behavior |
 
-***
+---
 
 ### Dialog
 
@@ -235,27 +229,27 @@ Accessible dialog/modal component built on top of the native `<dialog>` element.
 
 ```tsx
 <Dialog
-  behavior="modal"
-  opener={<button>Open Modal</button>}
-  onClose={() => console.log('Closed')}
+    behavior="modal"
+    opener={<button>Open Modal</button>}
+    onClose={() => console.log('Closed')}
 >
-  <p>This is a dialog!</p>
+    <p>This is a dialog!</p>
 </Dialog>
 ```
 
 **Props**
 
-| Prop        | Type                          | Description                                |
-|-------------|-------------------------------|---------------------------------------------|
-| `isOpen`    | `boolean`                     | Controlled open state (optional)           |
-| `behavior`  | `'dialog' \| 'modal'`         | Dialog type (default: `'modal'`)           |
-| `onOpen`    | `() => void`                  | Triggered on open                          |
-| `onClose`   | `() => void`                  | Triggered on close                         |
-| `opener`    | `ReactNode`                   | Element to trigger opening                 |
-| `children`  | `ReactNode`                   | Content inside the dialog                  |
+| Prop             | Type                        | Description                                 |
+| ---------------- | --------------------------- | ------------------------------------------- |
+| `isOpen`         | `boolean`                   | Controlled open state (optional)            |
+| `behavior`       | `'dialog' \| 'modal'`       | Dialog type (default: `'modal'`)            |
+| `onOpen`         | `() => void`                | Triggered on open                           |
+| `onClose`        | `() => void`                | Triggered on close                          |
+| `opener`         | `ReactNode`                 | Element to trigger opening                  |
+| `children`       | `ReactNode`                 | Content inside the dialog                   |
 | `...dialogProps` | All native `<dialog>` props | Inherits all HTML dialog element attributes |
 
-***
+---
 
 ### Observer
 
@@ -266,29 +260,29 @@ Tracks whether a child element is visible in the viewport using `IntersectionObs
 
 ```tsx
 <Observer
-  wrapper="section"
-  onAppear={() => console.log('Element appeared')}
-  onDisappear={() => console.log('Element disappeared')}
-  threshold={0.5}
+    wrapper="section"
+    onAppear={() => console.log('Element appeared')}
+    onDisappear={() => console.log('Element disappeared')}
+    threshold={0.5}
 >
-  <div>Watch me appear!</div>
+    <div>Watch me appear!</div>
 </Observer>
 ```
 
 **Props**
 
-| Prop          | Type                                       | Description                             |
-|---------------|--------------------------------------------|------------------------------------------|
-| `wrapper`     | `keyof ReactHTML` (default: `'div'`)       | HTML element to wrap children with        |
-| `onAppear`    | `(entry: IntersectionObserverEntry) => void` | Callback when element appears in viewport |
+| Prop          | Type                                         | Description                                    |
+| ------------- | -------------------------------------------- | ---------------------------------------------- |
+| `wrapper`     | `keyof ReactHTML` (default: `'div'`)         | HTML element to wrap children with             |
+| `onAppear`    | `(entry: IntersectionObserverEntry) => void` | Callback when element appears in viewport      |
 | `onDisappear` | `(entry: IntersectionObserverEntry) => void` | Callback when element disappears from viewport |
-| `threshold`   | `number \| number[]`                       | Intersection threshold (0-1)              |
-| `root`        | `Element \| null`                           | The element used as the viewport          |
-| `rootMargin`  | `string`                                    | Margin around the root                    |
+| `threshold`   | `number \| number[]`                         | Intersection threshold (0-1)                   |
+| `root`        | `Element \| null`                            | The element used as the viewport               |
+| `rootMargin`  | `string`                                     | Margin around the root                         |
 
 **Note**: This component extends `IntersectionObserverInit`, accepting all standard Intersection Observer options.
 
-***
+---
 
 ### LazyRender
 
@@ -299,27 +293,27 @@ Only renders children when they become visible in the viewport. Automatically un
 
 ```tsx
 <LazyRender
-  wrapper="section"
-  placeholder={<span>Loading...</span>}
-  threshold={0.5}
+    wrapper="section"
+    placeholder={<span>Loading...</span>}
+    threshold={0.5}
 >
-  <img src="/heavy-image.jpg" alt="Lazy" />
+    <img src="/heavy-image.jpg" alt="Lazy" />
 </LazyRender>
 ```
 
 **Props**
 
-| Prop         | Type                      | Description                              |
-|--------------|---------------------------|-------------------------------------------|
-| `wrapper`     | `keyof ReactHTML` (default: `'div'`) | HTML element to wrap children with        |
-| `placeholder`| `ReactNode`               | Rendered before children become visible   |
-| `threshold`  | `number \| number[]`      | Intersection threshold (0-1)              |
-| `root`        | `Element \| null`         | The element used as the viewport          |
-| `rootMargin`  | `string`                  | Margin around the root                    |
+| Prop          | Type                                 | Description                             |
+| ------------- | ------------------------------------ | --------------------------------------- |
+| `wrapper`     | `keyof ReactHTML` (default: `'div'`) | HTML element to wrap children with      |
+| `placeholder` | `ReactNode`                          | Rendered before children become visible |
+| `threshold`   | `number \| number[]`                 | Intersection threshold (0-1)            |
+| `root`        | `Element \| null`                    | The element used as the viewport        |
+| `rootMargin`  | `string`                             | Margin around the root                  |
 
 **Note**: This component extends `IntersectionObserverInit`, accepting all standard Intersection Observer options.
 
-***
+---
 
 ## 🪝 Hooks
 
@@ -331,50 +325,52 @@ Hook for checking and managing the availability of browser's AI APIs. This hook 
 **Example**
 
 ```tsx
-import { useAI } from '@galiprandi/react-tools';
+import { useAI } from '@galiprandi/react-tools'
 
 function MyComponent() {
-  // Check all APIs
-  const { isAvailable, apis, status } = useAI();
+    // Check all APIs
+    const { isAvailable, apis, status } = useAI()
 
-  // Check specific APIs
-  const { isAvailable, apis, preload } = useAI({ apis: ['translator', 'summarizer'] });
+    // Check specific APIs
+    const { isAvailable, apis, preload } = useAI({
+        apis: ['translator', 'summarizer'],
+    })
 
-  // Preload models
-  useEffect(() => {
-    if (isAvailable) {
-      preload('translator');
+    // Preload models
+    useEffect(() => {
+        if (isAvailable) {
+            preload('translator')
+        }
+    }, [isAvailable, preload])
+
+    // Show download progress
+    if (apis.translator.availability === 'downloading') {
+        const progress = apis.translator.progress
+        return <LoadingBar {...progress} />
     }
-  }, [isAvailable, preload]);
-
-  // Show download progress
-  if (apis.translator.availability === 'downloading') {
-    const progress = apis.translator.progress;
-    return <LoadingBar {...progress} />;
-  }
 }
 ```
 
 **Options**
 
-| Option      | Type      | Default | Description                                   |
-|-------------|-----------|---------|-----------------------------------------------|
-| `apis`      | `AIApiType[]` | All APIs | Specific APIs to check. If not provided, checks all APIs |
-| `onProgress` | `(api: AIApiType, progress: { loaded: number; total: number }) => void` | - | Callback when an API's download progress updates |
-| `onReady`    | `(api: AIApiType) => void` | - | Callback when an API becomes ready |
+| Option       | Type                                                                    | Default  | Description                                              |
+| ------------ | ----------------------------------------------------------------------- | -------- | -------------------------------------------------------- |
+| `apis`       | `AIApiType[]`                                                           | All APIs | Specific APIs to check. If not provided, checks all APIs |
+| `onProgress` | `(api: AIApiType, progress: { loaded: number; total: number }) => void` | -        | Callback when an API's download progress updates         |
+| `onReady`    | `(api: AIApiType) => void`                                              | -        | Callback when an API becomes ready                       |
 
 **Returns**
 
-| Property        | Type                          | Description                                 |
-|-----------------|-------------------------------|---------------------------------------------|
-| `isAvailable`   | `boolean`                     | Whether any of the requested APIs are available     |
-| `status`        | `'idle' \| 'loading' \| 'ready' \| 'error'` | The current status of the availability check |
-| `error`         | `Error \| null`               | Error object if the check failed           |
-| `apis`          | `Record<AIApiType, AIApiStatus>` | Status of each API                          |
-| `isApiAvailable`| `(api: AIApiType) => boolean` | Check if a specific API is available        |
-| `getApiProgress`| `(api: AIApiType) => { loaded: number; total: number } \| null` | Get download progress for a specific API   |
-| `preload`       | `(api: AIApiType) => Promise<void>` | Preload a specific API's model             |
-| `preloadAll`    | `() => Promise<void>`          | Preload all APIs' models                    |
+| Property         | Type                                                            | Description                                     |
+| ---------------- | --------------------------------------------------------------- | ----------------------------------------------- |
+| `isAvailable`    | `boolean`                                                       | Whether any of the requested APIs are available |
+| `status`         | `'idle' \| 'loading' \| 'ready' \| 'error'`                     | The current status of the availability check    |
+| `error`          | `Error \| null`                                                 | Error object if the check failed                |
+| `apis`           | `Record<AIApiType, AIApiStatus>`                                | Status of each API                              |
+| `isApiAvailable` | `(api: AIApiType) => boolean`                                   | Check if a specific API is available            |
+| `getApiProgress` | `(api: AIApiType) => { loaded: number; total: number } \| null` | Get download progress for a specific API        |
+| `preload`        | `(api: AIApiType) => Promise<void>`                             | Preload a specific API's model                  |
+| `preloadAll`     | `() => Promise<void>`                                           | Preload all APIs' models                        |
 
 **Supported APIs**
 
@@ -382,7 +378,7 @@ function MyComponent() {
 
 **Note**: This hook requires Chrome's Native AI APIs, which are currently experimental and may not be available in all browsers.
 
-***
+---
 
 ### useAISummarize
 
@@ -392,62 +388,65 @@ Hook for using the browser's AI Summarizer API. This hook provides a React inter
 **Example**
 
 ```tsx
-import { useAISummarize } from '@galiprandi/react-tools';
+import { useAISummarize } from '@galiprandi/react-tools'
 
 function MyComponent() {
-  const summarize = useAISummarize({
-    type: 'tldr',
-    format: 'markdown',
-    length: 'short',
-    outputLanguage: 'en',
-    streaming: true
-  });
+    const summarize = useAISummarize({
+        type: 'tldr',
+        format: 'markdown',
+        length: 'short',
+        outputLanguage: 'en',
+        streaming: true,
+    })
 
-  const handleSummarize = async () => {
-    await summarize.summarize(longText, 'End the summary with: Powered by my app');
-    console.log(summarize.data);
-  };
+    const handleSummarize = async () => {
+        await summarize.summarize(
+            longText,
+            'End the summary with: Powered by my app',
+        )
+        console.log(summarize.data)
+    }
 
-  return (
-    <div>
-      <button onClick={handleSummarize}>Summarize</button>
-      {summarize.status === 'summarizing' && <p>Summarizing...</p>}
-      {summarize.data && <p>{summarize.data}</p>}
-    </div>
-  );
+    return (
+        <div>
+            <button onClick={handleSummarize}>Summarize</button>
+            {summarize.status === 'summarizing' && <p>Summarizing...</p>}
+            {summarize.data && <p>{summarize.data}</p>}
+        </div>
+    )
 }
 ```
 
 **Options**
 
-| Option                    | Type                                          | Default      | Description                                   |
-|---------------------------|-----------------------------------------------|--------------|-----------------------------------------------|
-| `type`                    | `'tldr' \| 'key-points' \| 'teaser' \| 'headline'` | `undefined`  | Type of summary to generate                   |
-| `format`                  | `'plain-text' \| 'markdown'`                  | `undefined`  | Output format of the summary                  |
-| `length`                  | `'short' \| 'medium' \| 'long'`               | `undefined`  | Length of the summary                         |
-| `sharedContext`           | `string`                                      | `undefined`  | Shared context for all summaries               |
-| `expectedInputLanguages`  | `string[]`                                    | `undefined`  | Expected input languages (BCP 47 format)      |
-| `outputLanguage`          | `'en' \| 'es' \| 'ja' \| 'auto' \| 'user'`    | `'auto'`     | Output language. Use `'auto'` to detect from text (default), `'user'` for browser language, or specify a language code |
-| `expectedContextLanguages`| `string[]`                                    | `undefined`  | Expected context languages (BCP 47 format)    |
-| `preference`              | `'auto' \| 'capability'`                       | `'auto'`     | Performance preference (auto or capability)   |
-| `streaming`               | `boolean`                                     | `false`      | Enable streaming output for real-time results |
-| `warmup`                  | `boolean`                                     | `true`       | Preload model on mount for faster first summary |
+| Option                     | Type                                               | Default     | Description                                                                                                            |
+| -------------------------- | -------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `type`                     | `'tldr' \| 'key-points' \| 'teaser' \| 'headline'` | `undefined` | Type of summary to generate                                                                                            |
+| `format`                   | `'plain-text' \| 'markdown'`                       | `undefined` | Output format of the summary                                                                                           |
+| `length`                   | `'short' \| 'medium' \| 'long'`                    | `undefined` | Length of the summary                                                                                                  |
+| `sharedContext`            | `string`                                           | `undefined` | Shared context for all summaries                                                                                       |
+| `expectedInputLanguages`   | `string[]`                                         | `undefined` | Expected input languages (BCP 47 format)                                                                               |
+| `outputLanguage`           | `'en' \| 'es' \| 'ja' \| 'auto' \| 'user'`         | `'auto'`    | Output language. Use `'auto'` to detect from text (default), `'user'` for browser language, or specify a language code |
+| `expectedContextLanguages` | `string[]`                                         | `undefined` | Expected context languages (BCP 47 format)                                                                             |
+| `preference`               | `'auto' \| 'capability'`                           | `'auto'`    | Performance preference (auto or capability)                                                                            |
+| `streaming`                | `boolean`                                          | `false`     | Enable streaming output for real-time results                                                                          |
+| `warmup`                   | `boolean`                                          | `true`      | Preload model on mount for faster first summary                                                                        |
 
 **Returns**
 
-| Property              | Type                                        | Description                                                  |
-|-----------------------|---------------------------------------------|--------------------------------------------------------------|
-| `data`                | `string`                                    | The generated summary text                                  |
-| `status`              | `'idle' \| 'initializing' \| 'downloading' \| 'summarizing' \| 'success' \| 'error'` | Current status of the summarization process |
-| `progress`            | `{ loaded: number; total: number } \| null` | Download progress if model is being downloaded              |
-| `error`               | `Error \| null`                             | Error object if summarization failed                        |
-| `supportedPreferences` | `('auto' \| 'capability')[]`                 | Supported preference values based on browser capabilities    |
-| `summarize`           | `(text: string, context?: string) => Promise<void>` | Function to summarize text with optional context instruction |
-| `reset`               | `() => void`                                | Function to reset the hook state                            |
+| Property               | Type                                                                                 | Description                                                  |
+| ---------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------ |
+| `data`                 | `string`                                                                             | The generated summary text                                   |
+| `status`               | `'idle' \| 'initializing' \| 'downloading' \| 'summarizing' \| 'success' \| 'error'` | Current status of the summarization process                  |
+| `progress`             | `{ loaded: number; total: number } \| null`                                          | Download progress if model is being downloaded               |
+| `error`                | `Error \| null`                                                                      | Error object if summarization failed                         |
+| `supportedPreferences` | `('auto' \| 'capability')[]`                                                         | Supported preference values based on browser capabilities    |
+| `summarize`            | `(text: string, context?: string) => Promise<void>`                                  | Function to summarize text with optional context instruction |
+| `reset`                | `() => void`                                                                         | Function to reset the hook state                             |
 
 **Note**: This hook requires Chrome's AI Summarizer API, which is currently experimental and may not be available in all browsers. Use the `useAI` hook to check availability first.
 
-***
+---
 
 ### useLanguageDetection
 
@@ -457,35 +456,39 @@ Hook for using the browser's Language Detection API. This hook provides a React 
 **Example**
 
 ```tsx
-import { useLanguageDetection } from '@galiprandi/react-tools';
+import { useLanguageDetection } from '@galiprandi/react-tools'
 
 function MyComponent() {
-  const { lang, confidence, allLangs, userLang, isUserLang, status } = useLanguageDetection({
-    text: 'Hallo und herzlich willkommen!',
-    minConfidence: 0.8
-  });
+    const { lang, confidence, allLangs, userLang, isUserLang, status } =
+        useLanguageDetection({
+            text: 'Hallo und herzlich willkommen!',
+            minConfidence: 0.8,
+        })
 
-  return (
-    <div>
-      {status === 'detecting' && <p>Detecting...</p>}
-      {lang && (
-        <p>
-          Detected: {lang} ({Math.round(confidence! * 100)}% confidence)
-          {isUserLang && <span> (matches your language)</span>}
-        </p>
-      )}
-      {allLangs.length > 1 && (
-        <details>
-          <summary>All detected languages</summary>
-          <ul>
-            {allLangs.map(({ lang, confidence }) => (
-              <li key={lang}>{lang}: {Math.round(confidence * 100)}%</li>
-            ))}
-          </ul>
-        </details>
-      )}
-    </div>
-  );
+    return (
+        <div>
+            {status === 'detecting' && <p>Detecting...</p>}
+            {lang && (
+                <p>
+                    Detected: {lang} ({Math.round(confidence! * 100)}%
+                    confidence)
+                    {isUserLang && <span> (matches your language)</span>}
+                </p>
+            )}
+            {allLangs.length > 1 && (
+                <details>
+                    <summary>All detected languages</summary>
+                    <ul>
+                        {allLangs.map(({ lang, confidence }) => (
+                            <li key={lang}>
+                                {lang}: {Math.round(confidence * 100)}%
+                            </li>
+                        ))}
+                    </ul>
+                </details>
+            )}
+        </div>
+    )
 }
 ```
 
@@ -500,21 +503,21 @@ function MyComponent() {
 
 **Returns**
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `lang` | `string \| undefined` | The most likely detected language code (e.g., 'en', 'es') |
-| `confidence` | `number \| undefined` | Confidence of the most likely detection (0.0 - 1.0) |
-| `allLangs` | `DetectionResult[]` | All detected languages with confidence scores, ranked from most to least likely |
-| `userLang` | `string` | User's browser language code (e.g., 'en', 'es') |
-| `isUserLang` | `boolean` | Whether the detected language matches the user's browser language |
-| `status` | `'idle' \| 'initializing' \| 'downloading' \| 'detecting' \| 'success' \| 'error'` | Current status of the detection process |
-| `progress` | `{ loaded: number, total: number } \| null` | Download progress if model is being downloaded |
-| `error` | `Error \| null` | Error object if detection failed |
-| `reset` | `() => void` | Function to reset the hook state |
+| Property     | Type                                                                               | Description                                                                     |
+| ------------ | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `lang`       | `string \| undefined`                                                              | The most likely detected language code (e.g., 'en', 'es')                       |
+| `confidence` | `number \| undefined`                                                              | Confidence of the most likely detection (0.0 - 1.0)                             |
+| `allLangs`   | `DetectionResult[]`                                                                | All detected languages with confidence scores, ranked from most to least likely |
+| `userLang`   | `string`                                                                           | User's browser language code (e.g., 'en', 'es')                                 |
+| `isUserLang` | `boolean`                                                                          | Whether the detected language matches the user's browser language               |
+| `status`     | `'idle' \| 'initializing' \| 'downloading' \| 'detecting' \| 'success' \| 'error'` | Current status of the detection process                                         |
+| `progress`   | `{ loaded: number, total: number } \| null`                                        | Download progress if model is being downloaded                                  |
+| `error`      | `Error \| null`                                                                    | Error object if detection failed                                                |
+| `reset`      | `() => void`                                                                       | Function to reset the hook state                                                |
 
 **Note**: This hook requires Chrome's Language Detection API, which is currently experimental and may not be available in all browsers.
 
-***
+---
 
 ### useTranslator
 
@@ -524,51 +527,59 @@ Hook for using the browser's Translator API. This hook provides a React interfac
 **Example**
 
 ```tsx
-import { useTranslator } from '@galiprandi/react-tools';
+import { useTranslator } from '@galiprandi/react-tools'
 
 function MyComponent() {
-  // Auto-detect source language and translate to browser language
-  const { data, detectedSourceLanguage, resolvedTargetLanguage, status } = useTranslator({
-    text: 'Hello world, how are you?'
-  });
+    // Auto-detect source language and translate to browser language
+    const { data, detectedSourceLanguage, resolvedTargetLanguage, status } =
+        useTranslator({
+            text: 'Hello world, how are you?',
+        })
 
-  return (
-    <div>
-      {status === 'translating' && <p>Translating...</p>}
-      {data && (
-        <p>
-          {data}
-          {detectedSourceLanguage && <small> (from {detectedSourceLanguage} to {resolvedTargetLanguage})</small>}
-        </p>
-      )}
-    </div>
-  );
+    return (
+        <div>
+            {status === 'translating' && <p>Translating...</p>}
+            {data && (
+                <p>
+                    {data}
+                    {detectedSourceLanguage && (
+                        <small>
+                            {' '}
+                            (from {detectedSourceLanguage} to {
+                                resolvedTargetLanguage
+                            })
+                        </small>
+                    )}
+                </p>
+            )}
+        </div>
+    )
 }
 ```
 
 **Options**
 
-| Option          | Type      | Default | Description                                   |
-|-----------------|-----------|---------|-----------------------------------------------|
-| `text`          | `string`  | - | Text to translate. Auto-translates when changed |
-| `sourceLanguage`| `'auto' \| SupportedLanguage` | `'auto'` | Source language code. Use `'auto'` to detect from text automatically |
-| `targetLanguage`| `'user' \| SupportedLanguage` | `'user'` | Target language code. Use `'user'` for browser language |
-| `streaming`     | `boolean` | `false` | Enable streaming output for real-time results |
-| `warmup`        | `boolean` | `true` | Preload model on component mount for faster first translation |
-| `enable`        | `boolean` | `true` | Enable/disable auto-translation |
+| Option           | Type                          | Default  | Description                                                          |
+| ---------------- | ----------------------------- | -------- | -------------------------------------------------------------------- |
+| `text`           | `string`                      | -        | Text to translate. Auto-translates when changed                      |
+| `sourceLanguage` | `'auto' \| SupportedLanguage` | `'auto'` | Source language code. Use `'auto'` to detect from text automatically |
+| `targetLanguage` | `'user' \| SupportedLanguage` | `'user'` | Target language code. Use `'user'` for browser language              |
+| `streaming`      | `boolean`                     | `false`  | Enable streaming output for real-time results                        |
+| `warmup`         | `boolean`                     | `true`   | Preload model on component mount for faster first translation        |
+| `enable`         | `boolean`                     | `true`   | Enable/disable auto-translation                                      |
 
 **Returns**
 
-| Property   | Type                                        | Description                                                  |
-|------------|---------------------------------------------|--------------------------------------------------------------|
-| `data`     | `string`                                    | The translated text                                         |
-| `detectedSourceLanguage` | `string \| undefined` | Detected source language (when sourceLanguage is 'auto') |
-| `resolvedTargetLanguage` | `string \| undefined` | Resolved target language (when targetLanguage is 'user') |
-| `status`   | `'idle' \| 'initializing' \| 'downloading' \| 'translating' \| 'success' \| 'error'` | Current status of the translation process |
-| `progress` | `{ loaded: number; total: number } \| null` | Download progress if model is being downloaded              |
-| `error`    | `Error \| null`                             | Error object if translation failed                          |
-| `translate` | `(text: string) => Promise<void>`           | Function to translate text manually                        |
-| `reset`    | `() => void`                                | Function to reset the hook state                            |
+| Property                 | Type                                                                                 | Description                                              |
+| ------------------------ | ------------------------------------------------------------------------------------ | -------------------------------------------------------- |
+| `data`                   | `string`                                                                             | The translated text                                      |
+| `detectedSourceLanguage` | `string \| undefined`                                                                | Detected source language (when sourceLanguage is 'auto') |
+| `resolvedTargetLanguage` | `string \| undefined`                                                                | Resolved target language (when targetLanguage is 'user') |
+| `status`                 | `'idle' \| 'initializing' \| 'downloading' \| 'translating' \| 'success' \| 'error'` | Current status of the translation process                |
+| `progress`               | `{ loaded: number; total: number } \| null`                                          | Download progress if model is being downloaded           |
+| `error`                  | `Error \| null`                                                                      | Error object if translation failed                       |
+| `translate`              | `(text: string) => Promise<void>`                                                    | Function to translate text manually                      |
+| `reset`                  | `() => void`                                                                         | Function to reset the hook state                         |
 
 **Supported Languages**
 
@@ -576,7 +587,7 @@ function MyComponent() {
 
 **Note**: This hook requires Chrome's Translator API, which is currently experimental and may not be available in all browsers. Use the `useAI` hook to check availability first.
 
-***
+---
 
 ### useAIPrompt
 
@@ -586,84 +597,89 @@ Hook for using the browser's Prompt API (Gemini Nano) with multimodal support. T
 **Example**
 
 ```tsx
-import { useAIPrompt } from '@galiprandi/react-tools';
+import { useAIPrompt } from '@galiprandi/react-tools'
 
 function MyComponent() {
-  const { data, prompt, append, status, contextUsage, contextWindow } = useAIPrompt({
-    initialPrompts: [
-      { role: 'system', content: 'You are a helpful assistant.' }
-    ],
-    expectedInputs: [{ type: 'text' }, { type: 'image' }],
-    expectedOutputs: [{ type: 'text' }],
-    temperature: 0.7,
-    topK: 40,
-    streaming: true
-  });
+    const { data, prompt, append, status, contextUsage, contextWindow } =
+        useAIPrompt({
+            initialPrompts: [
+                { role: 'system', content: 'You are a helpful assistant.' },
+            ],
+            expectedInputs: [{ type: 'text' }, { type: 'image' }],
+            expectedOutputs: [{ type: 'text' }],
+            temperature: 0.7,
+            topK: 40,
+            streaming: true,
+        })
 
-  const handleSendWithImage = async (imageBlob: Blob) => {
-    await prompt([
-      { role: 'user', content: ['Describe this image:', imageBlob] }
-    ]);
-  };
+    const handleSendWithImage = async (imageBlob: Blob) => {
+        await prompt([
+            { role: 'user', content: ['Describe this image:', imageBlob] },
+        ])
+    }
 
-  const handleSend = async () => {
-    await prompt('What is the capital of France?');
-  };
+    const handleSend = async () => {
+        await prompt('What is the capital of France?')
+    }
 
-  return (
-    <div>
-      <button onClick={handleSend} disabled={status === 'prompting'}>
-        Send
-      </button>
-      {status === 'prompting' && <p>Thinking...</p>}
-      {status === 'downloading' && <p>Downloading model...</p>}
-      {data && <p>{data}</p>}
-      <small>Context: {contextUsage} / {contextWindow} tokens</small>
-    </div>
-  );
+    return (
+        <div>
+            <button onClick={handleSend} disabled={status === 'prompting'}>
+                Send
+            </button>
+            {status === 'prompting' && <p>Thinking...</p>}
+            {status === 'downloading' && <p>Downloading model...</p>}
+            {data && <p>{data}</p>}
+            <small>
+                Context: {contextUsage} / {contextWindow} tokens
+            </small>
+        </div>
+    )
 }
 ```
 
 **Options**
 
-| Option          | Type                      | Default | Description                                   |
-|-----------------|---------------------------|---------|-----------------------------------------------|
-| `initialPrompts`| `AIPromptMessage[]`       | -       | Initial prompts to provide context to the model (system/user/assistant roles) |
-| `temperature`    | `number`                  | -       | Temperature for sampling (higher is more creative) |
-| `topK`          | `number`                  | -       | Top-K sampling parameter                     |
-| `streaming`     | `boolean`                 | `false` | Enable streaming output for real-time results |
-| `warmup`        | `boolean`                 | `true`  | Preload model on component mount for faster first prompt |
-| `expectedInputs` | `{ type: 'text' \| 'image' \| 'audio' }[]` | - | Expected input types for multimodal support (e.g., `[{ type: 'text' }, { type: 'image' }]`) |
-| `expectedOutputs`| `{ type: 'text' }[]`       | - | Expected output types (e.g., `[{ type: 'text' }]`) |
+| Option            | Type                                       | Default | Description                                                                                 |
+| ----------------- | ------------------------------------------ | ------- | ------------------------------------------------------------------------------------------- |
+| `initialPrompts`  | `AIPromptMessage[]`                        | -       | Initial prompts to provide context to the model (system/user/assistant roles)               |
+| `temperature`     | `number`                                   | -       | Temperature for sampling (higher is more creative)                                          |
+| `topK`            | `number`                                   | -       | Top-K sampling parameter                                                                    |
+| `streaming`       | `boolean`                                  | `false` | Enable streaming output for real-time results                                               |
+| `warmup`          | `boolean`                                  | `true`  | Preload model on component mount for faster first prompt                                    |
+| `expectedInputs`  | `{ type: 'text' \| 'image' \| 'audio' }[]` | -       | Expected input types for multimodal support (e.g., `[{ type: 'text' }, { type: 'image' }]`) |
+| `expectedOutputs` | `{ type: 'text' }[]`                       | -       | Expected output types (e.g., `[{ type: 'text' }]`)                                          |
 
 **Returns**
 
-| Property        | Type                                        | Description                                                  |
-|-----------------|---------------------------------------------|--------------------------------------------------------------|
-| `data`          | `string`                                    | The AI response text                                        |
-| `status`        | `'idle' \| 'initializing' \| 'downloading' \| 'prompting' \| 'success' \| 'error'` | Current status of the prompt process |
-| `progress`      | `{ loaded: number; total: number } \| null` | Download progress if model is being downloaded              |
-| `error`         | `Error \| null`                             | Error object if prompting failed                            |
-| `prompt`        | `(input: string \| AILanguageModelPrompt[]) => Promise<void>` | Function to send a prompt to the AI (supports text or multimodal content) |
-| `append`        | `(input: AILanguageModelPrompt[]) => Promise<void>` | Function to append contextual messages without generating response (useful for preloading images/audio) |
-| `reset`         | `() => void`                                | Function to reset the hook state                            |
-| `contextUsage`  | `number`                                    | Number of tokens used in the current session                |
-| `contextWindow` | `number`                                    | Maximum number of tokens allowed in the session              |
+| Property        | Type                                                                               | Description                                                                                             |
+| --------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `data`          | `string`                                                                           | The AI response text                                                                                    |
+| `status`        | `'idle' \| 'initializing' \| 'downloading' \| 'prompting' \| 'success' \| 'error'` | Current status of the prompt process                                                                    |
+| `progress`      | `{ loaded: number; total: number } \| null`                                        | Download progress if model is being downloaded                                                          |
+| `error`         | `Error \| null`                                                                    | Error object if prompting failed                                                                        |
+| `prompt`        | `(input: string \| AILanguageModelPrompt[]) => Promise<void>`                      | Function to send a prompt to the AI (supports text or multimodal content)                               |
+| `append`        | `(input: AILanguageModelPrompt[]) => Promise<void>`                                | Function to append contextual messages without generating response (useful for preloading images/audio) |
+| `reset`         | `() => void`                                                                       | Function to reset the hook state                                                                        |
+| `contextUsage`  | `number`                                                                           | Number of tokens used in the current session                                                            |
+| `contextWindow` | `number`                                                                           | Maximum number of tokens allowed in the session                                                         |
 
 **Multimodal Support:**
 
 The hook supports automatic type inference for:
-- **Text**: strings
-- **Audio**: AudioBuffer, ArrayBuffer, ArrayBufferView, Blob (audio/*)
-- **Images**: HTMLImageElement, SVGImageElement, HTMLVideoElement, HTMLCanvasElement, ImageBitmap, OffscreenCanvas, VideoFrame, Blob (image/*), ImageData
+
+-   **Text**: strings
+-   **Audio**: AudioBuffer, ArrayBuffer, ArrayBufferView, Blob (audio/\*)
+-   **Images**: HTMLImageElement, SVGImageElement, HTMLVideoElement, HTMLCanvasElement, ImageBitmap, OffscreenCanvas, VideoFrame, Blob (image/\*), ImageData
 
 **Important Limitations:**
-- **Single content type per prompt**: The Chrome AI model currently has limitations processing multiple content types (e.g., image + audio) simultaneously in a single prompt. Send one type of multimodal content at a time for best results.
-- **Model capability**: Multimodal support depends on the specific Chrome AI model version and capabilities available in the browser.
+
+-   **Single content type per prompt**: The Chrome AI model currently has limitations processing multiple content types (e.g., image + audio) simultaneously in a single prompt. Send one type of multimodal content at a time for best results.
+-   **Model capability**: Multimodal support depends on the specific Chrome AI model version and capabilities available in the browser.
 
 **Note**: This hook requires Chrome's Prompt API (Gemini Nano), which is currently experimental and may not be available in all browsers. Use the `useAI` hook to check availability first.
 
-***
+---
 
 ### useAIWrite
 
@@ -673,81 +689,84 @@ Hook for using the browser's Writer API to generate written content with customi
 **Example**
 
 ```tsx
-import { useAIWrite } from '@galiprandi/react-tools';
+import { useAIWrite } from '@galiprandi/react-tools'
 
 function MyComponent() {
-  const { data, write, status, progress } = useAIWrite({
-    tone: 'formal',
-    format: 'markdown',
-    length: 'medium',
-    sharedContext: 'This is for a professional business email',
-    streaming: true
-  });
+    const { data, write, status, progress } = useAIWrite({
+        tone: 'formal',
+        format: 'markdown',
+        length: 'medium',
+        sharedContext: 'This is for a professional business email',
+        streaming: true,
+    })
 
-  const handleWrite = async () => {
-    await write('Write a thank you email to a colleague for their help on the project', 'I want to mention their attention to detail');
-  };
+    const handleWrite = async () => {
+        await write(
+            'Write a thank you email to a colleague for their help on the project',
+            'I want to mention their attention to detail',
+        )
+    }
 
-  return (
-    <div>
-      <button onClick={handleWrite} disabled={status === 'writing'}>
-        Generate
-      </button>
-      {status === 'writing' && <p>Writing...</p>}
-      {status === 'downloading' && <p>Downloading model...</p>}
-      {data && <p>{data}</p>}
-    </div>
-  );
+    return (
+        <div>
+            <button onClick={handleWrite} disabled={status === 'writing'}>
+                Generate
+            </button>
+            {status === 'writing' && <p>Writing...</p>}
+            {status === 'downloading' && <p>Downloading model...</p>}
+            {data && <p>{data}</p>}
+        </div>
+    )
 }
 ```
 
 **Options**
 
-| Option          | Type                      | Default | Description                                   |
-|-----------------|---------------------------|---------|-----------------------------------------------|
-| `tone`          | `'formal' \| 'neutral' \| 'casual'` | `'neutral'` | Writing tone: formal (professional), neutral (balanced), casual (friendly) |
-| `format`        | `'markdown' \| 'plain-text'` | `'markdown'` | Output format: markdown (formatted) or plain-text |
-| `length`        | `'short' \| 'medium' \| 'long'` | `'short'` | Length of the output: short (brief), medium (moderate), long (detailed) |
-| `sharedContext` | `string`                  | -       | Shared context for all writing tasks (helps maintain consistency across multiple writes) |
-| `outputLanguage`| `string`                  | -       | Output language (BCP 47 format, e.g., 'en', 'es', 'fr') |
-| `expectedInputLanguages` | `string[]`      | -       | Expected input languages (BCP 47 format) |
-| `expectedContextLanguages` | `string[]` | -       | Expected context languages (BCP 47 format) |
-| `streaming`     | `boolean`                 | `false` | Enable streaming output for real-time results |
-| `warmup`        | `boolean`                 | `true`  | Preload model on component mount for faster first write |
+| Option                     | Type                                | Default      | Description                                                                              |
+| -------------------------- | ----------------------------------- | ------------ | ---------------------------------------------------------------------------------------- |
+| `tone`                     | `'formal' \| 'neutral' \| 'casual'` | `'neutral'`  | Writing tone: formal (professional), neutral (balanced), casual (friendly)               |
+| `format`                   | `'markdown' \| 'plain-text'`        | `'markdown'` | Output format: markdown (formatted) or plain-text                                        |
+| `length`                   | `'short' \| 'medium' \| 'long'`     | `'short'`    | Length of the output: short (brief), medium (moderate), long (detailed)                  |
+| `sharedContext`            | `string`                            | -            | Shared context for all writing tasks (helps maintain consistency across multiple writes) |
+| `outputLanguage`           | `string`                            | -            | Output language (BCP 47 format, e.g., 'en', 'es', 'fr')                                  |
+| `expectedInputLanguages`   | `string[]`                          | -            | Expected input languages (BCP 47 format)                                                 |
+| `expectedContextLanguages` | `string[]`                          | -            | Expected context languages (BCP 47 format)                                               |
+| `streaming`                | `boolean`                           | `false`      | Enable streaming output for real-time results                                            |
+| `warmup`                   | `boolean`                           | `true`       | Preload model on component mount for faster first write                                  |
 
 **Returns**
 
-| Property        | Type                                        | Description                                                  |
-|-----------------|---------------------------------------------|--------------------------------------------------------------|
-| `data`          | `string`                                    | The generated written content                                |
-| `status`        | `'idle' \| 'initializing' \| 'downloading' \| 'writing' \| 'success' \| 'error'` | Current status of the writing process |
-| `progress`      | `{ loaded: number; total: number } \| null` | Download progress if model is being downloaded              |
-| `error`         | `Error \| null`                             | Error object if writing failed                              |
-| `write`         | `(prompt: string, context?: string) => Promise<void>` | Function to generate written content with optional context |
-| `reset`         | `() => void`                                | Function to reset the hook state                            |
+| Property   | Type                                                                             | Description                                                |
+| ---------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `data`     | `string`                                                                         | The generated written content                              |
+| `status`   | `'idle' \| 'initializing' \| 'downloading' \| 'writing' \| 'success' \| 'error'` | Current status of the writing process                      |
+| `progress` | `{ loaded: number; total: number } \| null`                                      | Download progress if model is being downloaded             |
+| `error`    | `Error \| null`                                                                  | Error object if writing failed                             |
+| `write`    | `(prompt: string, context?: string) => Promise<void>`                            | Function to generate written content with optional context |
+| `reset`    | `() => void`                                                                     | Function to reset the hook state                           |
 
 **Features:**
 
-- **Multiple Tones**: Choose between formal, neutral, or casual writing styles
-- **Format Options**: Output in markdown or plain-text
-- **Length Control**: Generate short, medium, or long content
-- **Shared Context**: Maintain consistency across multiple writing tasks
-- **Language Support**: Specify expected input/output languages
-- **Streaming**: Real-time content generation for better UX
-- **Reusable Writer**: The same writer instance can be used for multiple writes
+-   **Multiple Tones**: Choose between formal, neutral, or casual writing styles
+-   **Format Options**: Output in markdown or plain-text
+-   **Length Control**: Generate short, medium, or long content
+-   **Shared Context**: Maintain consistency across multiple writing tasks
+-   **Language Support**: Specify expected input/output languages
+-   **Streaming**: Real-time content generation for better UX
+-   **Reusable Writer**: The same writer instance can be used for multiple writes
 
 **Use Cases:**
 
-- Email generation (professional, casual, thank you, follow-up)
-- Blog post writing
-- Social media content creation
-- Document drafting
-- Report generation
-- Marketing copy
+-   Email generation (professional, casual, thank you, follow-up)
+-   Blog post writing
+-   Social media content creation
+-   Document drafting
+-   Report generation
+-   Marketing copy
 
 **Note**: This hook requires Chrome's Writer API, which is currently experimental and may not be available in all browsers. Use the `useAI` hook to check availability first.
 
-***
+---
 
 ### useAIRewriter
 
@@ -757,83 +776,86 @@ Hook for using the browser's Rewriter API to rewrite and restructure text with c
 **Example**
 
 ```tsx
-import { useAIRewriter } from '@galiprandi/react-tools';
+import { useAIRewriter } from '@galiprandi/react-tools'
 
 function MyComponent() {
-  const { data, rewrite, status, progress } = useAIRewriter({
-    tone: 'more-formal',
-    format: 'markdown',
-    length: 'shorter',
-    sharedContext: 'This is for a professional business email',
-    streaming: true
-  });
+    const { data, rewrite, status, progress } = useAIRewriter({
+        tone: 'more-formal',
+        format: 'markdown',
+        length: 'shorter',
+        sharedContext: 'This is for a professional business email',
+        streaming: true,
+    })
 
-  const handleRewrite = async () => {
-    await rewrite('Hi, I wanted to let you know the project is going well.', 'Make it more professional');
-  };
+    const handleRewrite = async () => {
+        await rewrite(
+            'Hi, I wanted to let you know the project is going well.',
+            'Make it more professional',
+        )
+    }
 
-  return (
-    <div>
-      <button onClick={handleRewrite} disabled={status === 'rewriting'}>
-        Rewrite
-      </button>
-      {status === 'rewriting' && <p>Rewriting...</p>}
-      {status === 'downloading' && <p>Downloading model...</p>}
-      {data && <p>{data}</p>}
-    </div>
-  );
+    return (
+        <div>
+            <button onClick={handleRewrite} disabled={status === 'rewriting'}>
+                Rewrite
+            </button>
+            {status === 'rewriting' && <p>Rewriting...</p>}
+            {status === 'downloading' && <p>Downloading model...</p>}
+            {data && <p>{data}</p>}
+        </div>
+    )
 }
 ```
 
 **Options**
 
-| Option          | Type                      | Default | Description                                   |
-|-----------------|---------------------------|---------|-----------------------------------------------|
-| `tone`          | `'more-formal' \| 'as-is' \| 'more-casual'` | `'as-is'` | Writing tone: more-formal (professional), as-is (balanced), more-casual (friendly) |
-| `format`        | `'as-is' \| 'markdown' \| 'plain-text'` | `'as-is'` | Output format: as-is (preserve original), markdown (formatted), plain-text |
-| `length`        | `'shorter' \| 'as-is' \| 'longer'` | `'as-is'` | Length of the output: shorter (condense), as-is (preserve), longer (expand) |
-| `sharedContext` | `string`                  | -       | Shared context for all rewriting tasks (helps maintain consistency across multiple rewrites) |
-| `outputLanguage`| `string`                  | -       | Output language (BCP 47 format, e.g., 'en', 'es', 'fr') |
-| `expectedInputLanguages` | `string[]`      | -       | Expected input languages (BCP 47 format) |
-| `expectedContextLanguages` | `string[]` | -       | Expected context languages (BCP 47 format) |
-| `streaming`     | `boolean`                 | `false` | Enable streaming output for real-time results |
-| `warmup`        | `boolean`                 | `true`  | Preload model on component mount for faster first rewrite |
+| Option                     | Type                                        | Default   | Description                                                                                  |
+| -------------------------- | ------------------------------------------- | --------- | -------------------------------------------------------------------------------------------- |
+| `tone`                     | `'more-formal' \| 'as-is' \| 'more-casual'` | `'as-is'` | Writing tone: more-formal (professional), as-is (balanced), more-casual (friendly)           |
+| `format`                   | `'as-is' \| 'markdown' \| 'plain-text'`     | `'as-is'` | Output format: as-is (preserve original), markdown (formatted), plain-text                   |
+| `length`                   | `'shorter' \| 'as-is' \| 'longer'`          | `'as-is'` | Length of the output: shorter (condense), as-is (preserve), longer (expand)                  |
+| `sharedContext`            | `string`                                    | -         | Shared context for all rewriting tasks (helps maintain consistency across multiple rewrites) |
+| `outputLanguage`           | `string`                                    | -         | Output language (BCP 47 format, e.g., 'en', 'es', 'fr')                                      |
+| `expectedInputLanguages`   | `string[]`                                  | -         | Expected input languages (BCP 47 format)                                                     |
+| `expectedContextLanguages` | `string[]`                                  | -         | Expected context languages (BCP 47 format)                                                   |
+| `streaming`                | `boolean`                                   | `false`   | Enable streaming output for real-time results                                                |
+| `warmup`                   | `boolean`                                   | `true`    | Preload model on component mount for faster first rewrite                                    |
 
 **Returns**
 
-| Property        | Type                                        | Description                                                  |
-|-----------------|---------------------------------------------|--------------------------------------------------------------|
-| `data`          | `string`                                    | The rewritten text                                         |
-| `status`        | `'idle' \| 'initializing' \| 'downloading' \| 'rewriting' \| 'success' \| 'error'` | Current status of the rewriting process |
-| `progress`      | `{ loaded: number; total: number } \| null` | Download progress if model is being downloaded              |
-| `error`         | `Error \| null`                             | Error object if rewriting failed                            |
-| `rewrite`       | `(text: string, context?: string, overrideTone?: 'more-formal' \| 'as-is' \| 'more-casual') => Promise<void>` | Function to rewrite text with optional context and tone override |
-| `reset`         | `() => void`                                | Function to reset the hook state                            |
+| Property   | Type                                                                                                          | Description                                                      |
+| ---------- | ------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `data`     | `string`                                                                                                      | The rewritten text                                               |
+| `status`   | `'idle' \| 'initializing' \| 'downloading' \| 'rewriting' \| 'success' \| 'error'`                            | Current status of the rewriting process                          |
+| `progress` | `{ loaded: number; total: number } \| null`                                                                   | Download progress if model is being downloaded                   |
+| `error`    | `Error \| null`                                                                                               | Error object if rewriting failed                                 |
+| `rewrite`  | `(text: string, context?: string, overrideTone?: 'more-formal' \| 'as-is' \| 'more-casual') => Promise<void>` | Function to rewrite text with optional context and tone override |
+| `reset`    | `() => void`                                                                                                  | Function to reset the hook state                                 |
 
 **Features:**
 
-- **Multiple Tones**: Adjust tone to be more formal, keep as-is, or more casual
-- **Format Options**: Preserve original format, convert to markdown, or plain-text
-- **Length Control**: Condense (shorter), preserve (as-is), or expand (longer) content
-- **Shared Context**: Maintain consistency across multiple rewriting tasks
-- **Language Support**: Specify expected input/output languages
-- **Streaming**: Real-time content generation for better UX
-- **Tone Override**: Override global tone setting per rewrite
-- **Reusable Rewriter**: The same rewriter instance can be used for multiple rewrites
+-   **Multiple Tones**: Adjust tone to be more formal, keep as-is, or more casual
+-   **Format Options**: Preserve original format, convert to markdown, or plain-text
+-   **Length Control**: Condense (shorter), preserve (as-is), or expand (longer) content
+-   **Shared Context**: Maintain consistency across multiple rewriting tasks
+-   **Language Support**: Specify expected input/output languages
+-   **Streaming**: Real-time content generation for better UX
+-   **Tone Override**: Override global tone setting per rewrite
+-   **Reusable Rewriter**: The same rewriter instance can be used for multiple rewrites
 
 **Use Cases:**
 
-- Email tone adjustment (make more professional or casual)
-- Content condensation (summarize long text)
-- Content expansion (add detail and elaboration)
-- Style improvement (enhance readability and flow)
-- Audience adaptation (rewrite for different audiences)
-- Review polishing (improve feedback constructiveness)
-- Format conversion (convert to markdown or plain-text)
+-   Email tone adjustment (make more professional or casual)
+-   Content condensation (summarize long text)
+-   Content expansion (add detail and elaboration)
+-   Style improvement (enhance readability and flow)
+-   Audience adaptation (rewrite for different audiences)
+-   Review polishing (improve feedback constructiveness)
+-   Format conversion (convert to markdown or plain-text)
 
 **Note**: This hook requires Chrome's Rewriter API, which is currently experimental and may not be available in all browsers. Use the `useAI` hook to check availability first.
 
-***
+---
 
 ### useAIProofreader
 
@@ -843,87 +865,92 @@ Hook for using the browser's Proofreader API to check grammar and spelling with 
 **Example**
 
 ```tsx
-import { useAIProofreader } from '@galiprandi/react-tools';
+import { useAIProofreader } from '@galiprandi/react-tools'
 
 function MyComponent() {
-  const { data, corrections, proofread, status, progress } = useAIProofreader({
-    expectedInputLanguages: ['en'],
-  });
+    const { data, corrections, proofread, status, progress } = useAIProofreader(
+        {
+            expectedInputLanguages: ['en'],
+        },
+    )
 
-  const handleProofread = async () => {
-    await proofread('I seen him yesterday at the store.');
-  };
+    const handleProofread = async () => {
+        await proofread('I seen him yesterday at the store.')
+    }
 
-  return (
-    <div>
-      <button onClick={handleProofread} disabled={status === 'proofreading'}>
-        Proofread
-      </button>
-      {status === 'proofreading' && <p>Proofreading...</p>}
-      {status === 'downloading' && <p>Downloading model...</p>}
-      {data && <p>{data}</p>}
-      {corrections.length > 0 && (
-        <ul>
-          {corrections.map((c, i) => (
-            <li key={i}>
-              {c.type && <span>Type: {c.type}</span>}
-              {c.explanation && <span> - {c.explanation}</span>}
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
+    return (
+        <div>
+            <button
+                onClick={handleProofread}
+                disabled={status === 'proofreading'}
+            >
+                Proofread
+            </button>
+            {status === 'proofreading' && <p>Proofreading...</p>}
+            {status === 'downloading' && <p>Downloading model...</p>}
+            {data && <p>{data}</p>}
+            {corrections.length > 0 && (
+                <ul>
+                    {corrections.map((c, i) => (
+                        <li key={i}>
+                            {c.type && <span>Type: {c.type}</span>}
+                            {c.explanation && <span> - {c.explanation}</span>}
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    )
 }
 ```
 
 **Options**
 
-| Option          | Type                      | Default | Description                                   |
-|-----------------|---------------------------|---------|-----------------------------------------------|
-| `expectedInputLanguages` | `string[]`      | -       | Expected input languages (BCP 47 format, e.g., 'en', 'es') |
-| `warmup`        | `boolean`                 | `true`  | Preload model on component mount for faster first proofread |
+| Option                   | Type       | Default | Description                                                 |
+| ------------------------ | ---------- | ------- | ----------------------------------------------------------- |
+| `expectedInputLanguages` | `string[]` | -       | Expected input languages (BCP 47 format, e.g., 'en', 'es')  |
+| `warmup`                 | `boolean`  | `true`  | Preload model on component mount for faster first proofread |
 
 **Returns**
 
-| Property        | Type                                        | Description                                                  |
-|-----------------|---------------------------------------------|--------------------------------------------------------------|
-| `data`          | `string`                                    | The corrected text                                         |
-| `corrections`   | `ProofreadCorrection[]`                     | Array of corrections with startIndex, endIndex, type, and explanation |
-| `status`        | `'idle' \| 'initializing' \| 'downloading' \| 'proofreading' \| 'success' \| 'error'` | Current status of the proofreading process |
-| `progress`      | `{ loaded: number; total: number } \| null` | Download progress if model is being downloaded              |
-| `error`         | `Error \| null`                             | Error object if proofreading failed                          |
-| `proofread`     | `(text: string) => Promise<void>`           | Function to proofread text                                  |
-| `reset`         | `() => void`                                | Function to reset the hook state                            |
+| Property      | Type                                                                                  | Description                                                           |
+| ------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `data`        | `string`                                                                              | The corrected text                                                    |
+| `corrections` | `ProofreadCorrection[]`                                                               | Array of corrections with startIndex, endIndex, type, and explanation |
+| `status`      | `'idle' \| 'initializing' \| 'downloading' \| 'proofreading' \| 'success' \| 'error'` | Current status of the proofreading process                            |
+| `progress`    | `{ loaded: number; total: number } \| null`                                           | Download progress if model is being downloaded                        |
+| `error`       | `Error \| null`                                                                       | Error object if proofreading failed                                   |
+| `proofread`   | `(text: string) => Promise<void>`                                                     | Function to proofread text                                            |
+| `reset`       | `() => void`                                                                          | Function to reset the hook state                                      |
 
 **ProofreadCorrection:**
 
-- `startIndex`: Start index of the correction in the original text
-- `endIndex`: End index of the correction in the original text
-- `type`: Type of correction (e.g., 'grammar', 'spelling')
-- `explanation`: Explanation of the correction
+-   `startIndex`: Start index of the correction in the original text
+-   `endIndex`: End index of the correction in the original text
+-   `type`: Type of correction (e.g., 'grammar', 'spelling')
+-   `explanation`: Explanation of the correction
 
 **Features:**
 
-- **Grammar Checking**: Detect and correct grammatical errors
-- **Spelling Correction**: Identify and fix spelling mistakes
-- **Detailed Corrections**: Get correction type and explanation for each issue
-- **Language Support**: Specify expected input languages for better accuracy
-- **Fast Proofreading**: Warmup option for faster first proofread
-- **Reusable Proofreader**: The same proofreader instance can be used for multiple checks
+-   **Grammar Checking**: Detect and correct grammatical errors
+-   **Spelling Correction**: Identify and fix spelling mistakes
+-   **Detailed Corrections**: Get correction type and explanation for each issue
+-   **Language Support**: Specify expected input languages for better accuracy
+-   **Fast Proofreading**: Warmup option for faster first proofread
+-   **Reusable Proofreader**: The same proofreader instance can be used for multiple checks
 
 **Use Cases:**
 
-- Text editing (grammar and spell checking)
-- Content review (improving writing quality)
-- Email validation (catching typos before sending)
-- Document proofreading (ensuring professional quality)
-- Blog post review (improving readability)
-- Comment moderation (identifying language issues)
+-   Text editing (grammar and spell checking)
+-   Content review (improving writing quality)
+-   Email validation (catching typos before sending)
+-   Document proofreading (ensuring professional quality)
+-   Blog post review (improving readability)
+-   Comment moderation (identifying language issues)
 
 **Note**: This hook requires Chrome's Proofreader API, which is currently experimental and may not be available in all browsers. Use the `useAI` hook to check availability first.
 
-***
+---
 
 ### useDebounce
 
@@ -933,20 +960,20 @@ A React hook that returns a debounced version of a value. Useful for search inpu
 **Example**
 
 ```tsx
-const debouncedSearch = useDebounce(searchTerm, 500);
+const debouncedSearch = useDebounce(searchTerm, 500)
 ```
 
 **Props**
 
-| Parameter     | Type      | Description                    |
-|---------------|-----------|--------------------------------|
-| `value`       | `T`       | Value to debounce              |
-| `delay`       | `number`  | Delay in milliseconds          |
+| Parameter | Type     | Description           |
+| --------- | -------- | --------------------- |
+| `value`   | `T`      | Value to debounce     |
+| `delay`   | `number` | Delay in milliseconds |
 
 **Returns**\
 Debounced version of the value (`T`).
 
-***
+---
 
 ### useThrottle
 
@@ -956,20 +983,20 @@ A React hook that returns a throttled version of a value. Ensures the value upda
 **Example**
 
 ```tsx
-const throttledValue = useThrottle(value, 500);
+const throttledValue = useThrottle(value, 500)
 ```
 
 **Props**
 
-| Parameter     | Type      | Description                    |
-|---------------|-----------|--------------------------------|
-| `value`       | `T`       | Value to throttle              |
-| `limit`       | `number`  | Limit in milliseconds          |
+| Parameter | Type     | Description           |
+| --------- | -------- | --------------------- |
+| `value`   | `T`      | Value to throttle     |
+| `limit`   | `number` | Limit in milliseconds |
 
 **Returns**\
 Throttled version of the value (`T`).
 
-***
+---
 
 ### useTimer
 
@@ -978,74 +1005,77 @@ A React hook that abstracts the complexity of managing `setTimeout` and `setInte
 
 **Features**
 
-* **Automatic Cleanup:** Timers are automatically cleared when the component using the hook unmounts, preventing memory leaks.
-* **Lifecycle Events:** Receive notifications when a timer is set, cancelled, completes, or reports progress.
-* **Flexible Scheduling:** Set timers by milliseconds, a future `Date` object, or as limited intervals.
-* **Simplified Control:** Clear any active timer with a single method call.
+-   **Automatic Cleanup:** Timers are automatically cleared when the component using the hook unmounts, preventing memory leaks.
+-   **Lifecycle Events:** Receive notifications when a timer is set, cancelled, completes, or reports progress.
+-   **Flexible Scheduling:** Set timers by milliseconds, a future `Date` object, or as limited intervals.
+-   **Simplified Control:** Clear any active timer with a single method call.
 
 **Example**
 
 ```tsx
-import { useEffect } from 'react';
-import { useTimer } from '@galiprandi/react-tools';
+import { useEffect } from 'react'
+import { useTimer } from '@galiprandi/react-tools'
 
 function FutureExecution({ targetDate }: { targetDate: Date }) {
-  const { setTimeoutDate, clearTimer } = useTimer({
-    onSetTimer: (id) => console.log(`Timer ID ${id} set for future execution`),
-    onTimerComplete: (id) => console.log(`Timer ID ${id} completed!`),
-    onCancelTimer: (id) => console.log(`Timer ID ${id} cancelled!`),
-    onProgress: (progress) =>
-      console.log(`Progress: ${Math.round(progress * 100)}%`),
-  });
+    const { setTimeoutDate, clearTimer } = useTimer({
+        onSetTimer: (id) =>
+            console.log(`Timer ID ${id} set for future execution`),
+        onTimerComplete: (id) => console.log(`Timer ID ${id} completed!`),
+        onCancelTimer: (id) => console.log(`Timer ID ${id} cancelled!`),
+        onProgress: (progress) =>
+            console.log(`Progress: ${Math.round(progress * 100)}%`),
+    })
 
-  useEffect(() => {
-    console.log(`Scheduling action for: ${targetDate.toLocaleTimeString()}`);
+    useEffect(() => {
+        console.log(`Scheduling action for: ${targetDate.toLocaleTimeString()}`)
 
-    setTimeoutDate(() => {
-      // Do something here, like a fake fetch request
-      console.log("--- Fake fetch executed! ---");
-    }, targetDate);
+        setTimeoutDate(() => {
+            // Do something here, like a fake fetch request
+            console.log('--- Fake fetch executed! ---')
+        }, targetDate)
 
-    // ⚠️ Remember to clear the timer when the component unmounts or when the targetDate changes
-    return () => {
-      console.log('Component unmounting or targetDate change, clearing timer.');
-      clearTimer();
-    };
-  }, [setTimeoutDate, clearTimer, targetDate]);
+        // ⚠️ Remember to clear the timer when the component unmounts or when the targetDate changes
+        return () => {
+            console.log(
+                'Component unmounting or targetDate change, clearing timer.',
+            )
+            clearTimer()
+        }
+    }, [setTimeoutDate, clearTimer, targetDate])
 
-  return (
-    <div>
-      <p>Check the console for timer messages.</p>
-    </div>
-  );
+    return (
+        <div>
+            <p>Check the console for timer messages.</p>
+        </div>
+    )
 }
 ```
 
 **Parameters (options)**
 
-| Parameter         | Type                               | Description                                                     |
-|-------------------|------------------------------------|-----------------------------------------------------------------|
-| `onSetTimer`      | `(timerId: number) => void`        | Callback fired when a new timer is successfully set.            |
-| `onCancelTimer`   | `(timerId: number) => void`        | Callback fired when an active timer is cleared/cancelled.       |
-| `onTimerComplete` | `(timerId: number) => void`        | Callback fired when a timer completes naturally (timeout) or for each interval execution (interval/limited interval). |
-| `onProgress`      | `(progress: number, elapsedMs: number, totalMs: number) => void` | Callback fired periodically during long timers (`setTimeout`) and limited intervals to report progress (0 to 1). |
+| Parameter         | Type                                                             | Description                                                                                                           |
+| ----------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `onSetTimer`      | `(timerId: number) => void`                                      | Callback fired when a new timer is successfully set.                                                                  |
+| `onCancelTimer`   | `(timerId: number) => void`                                      | Callback fired when an active timer is cleared/cancelled.                                                             |
+| `onTimerComplete` | `(timerId: number) => void`                                      | Callback fired when a timer completes naturally (timeout) or for each interval execution (interval/limited interval). |
+| `onProgress`      | `(progress: number, elapsedMs: number, totalMs: number) => void` | Callback fired periodically during long timers (`setTimeout`) and limited intervals to report progress (0 to 1).      |
 
 **Returns**
 An object containing control methods and status/info getters.
 
-| Property               | Type                                                     | Description                                                              |
-|------------------------|----------------------------------------------------------|--------------------------------------------------------------------------|
-| `setTimeout`           | `(callback: () => void, delay: number \| Date) => number \| null` | Sets a timeout with event callbacks. Accepts milliseconds or a future `Date`. Returns the timer ID. |
-| `setInterval`          | `(callback: () => void, delay: number) => number \| null`       | Sets an interval with event callbacks. Accepts milliseconds. Returns the timer ID. |
-| `setTimeoutDate`       | `(callback: () => void, targetDate: Date) => number \| null`    | Sets a timeout to execute at a specific future `Date`. Returns the timer ID. |
-| `setLimitedInterval`   | `(callback: () => void, delay: number, iterations: number) => number \| null` | Sets an interval that executes a fixed number of times. Returns the timer ID. |
-| `clearTimer`           | `() => void`                                             | Clears any currently active timer set by this hook instance.             |
-| `isActive`             | `() => boolean`                                          | Returns `true` if a timer is currently active, `false` otherwise.        |
-| `getCurrentTimerId`    | `() => number \| null`                                   | Returns the ID of the currently active timer, or `null`.                 |
-| `getRemainingIterations`| `() => number \| null`                                   | For `setLimitedInterval`, returns remaining executions.                  |
-| `getRemainingTime`     | `() => number`                                           | For an active `setTimeout`, returns estimated remaining time in ms, otherwise `-1`. |
+| Property                 | Type                                                                          | Description                                                                                         |
+| ------------------------ | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `setTimeout`             | `(callback: () => void, delay: number \| Date) => number \| null`             | Sets a timeout with event callbacks. Accepts milliseconds or a future `Date`. Returns the timer ID. |
+| `setInterval`            | `(callback: () => void, delay: number) => number \| null`                     | Sets an interval with event callbacks. Accepts milliseconds. Returns the timer ID.                  |
+| `setTimeoutDate`         | `(callback: () => void, targetDate: Date) => number \| null`                  | Sets a timeout to execute at a specific future `Date`. Returns the timer ID.                        |
+| `setLimitedInterval`     | `(callback: () => void, delay: number, iterations: number) => number \| null` | Sets an interval that executes a fixed number of times. Returns the timer ID.                       |
+| `clearTimer`             | `() => void`                                                                  | Clears any currently active timer set by this hook instance.                                        |
+| `isActive`               | `() => boolean`                                                               | Returns `true` if a timer is currently active, `false` otherwise.                                   |
+| `getCurrentTimerId`      | `() => number \| null`                                                        | Returns the ID of the currently active timer, or `null`.                                            |
+| `getRemainingIterations` | `() => number \| null`                                                        | For `setLimitedInterval`, returns remaining executions.                                             |
+| `getRemainingTime`       | `() => number`                                                                | For an active `setTimeout`, returns estimated remaining time in ms, otherwise `-1`.                 |
 
-***
+---
 
 ### useList
 
@@ -1054,46 +1084,47 @@ A React hook that simplifies managing array state in components. It provides imm
 
 **Parameters**
 
-| Parameter   | Type   | Description                                 |
-|-------------|--------|---------------------------------------------|
-| `initialList`| `T[]`  | The initial array state (defaults to `[]`) |
+| Parameter     | Type  | Description                                |
+| ------------- | ----- | ------------------------------------------ |
+| `initialList` | `T[]` | The initial array state (defaults to `[]`) |
 
 **Returns**
 An object containing the current array state (`list`) and helper functions to modify or query it immutably.
 
-| Property         | Type                                                        | Description                                                                                                                               |
-|------------------|-------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| `list`           | `T[]`                                                       | The current array state.                                                                                                                  |
-| `addItem`        | `(item: T) => void`                                         | Adds an `item` to the end of the array.                                                                                                   |
-| `insert`         | `(index: number, item: T) => void`                          | Inserts an `item` at the specified `index`. If the index is out of bounds, the item is added to the beginning (index < 0) or end (index > length). |
-| `insertMany`     | `(items: T[]) => void`                                      | Adds multiple `items` to the end of the array. Does nothing if input is not an array or is empty.                                       |
-| `removeByIdx`    | `(index: number) => void`                                   | Removes the item at the specified `index`. If the index is out of bounds, the list remains unchanged. |
-| `removeBy`       | `(key: string \| undefined \| null, value: any) => void`    | Removes the **first** item where `item[key]` strictly equals `value`. If `key` is `undefined` or `null`, removes the first item where `item` strictly equals `value` (useful for primitives). If no match is found, the list remains unchanged. |
-| `removeManyBy`   | `(key: string \| undefined \| null, value: any) => void`    | Removes **all** items where `item[key]` strictly equals `value`. If `key` is `undefined` or `null`, removes all items where `item` strictly equals `value` (useful for primitives). If no match is found, the list remains unchanged. |
-| `updateByIdx`    | `(index: number, updateFn: (item: T) => T) => void`         | Updates the item at the specified `index` using an immutable `updateFn`. If the index is out of bounds, the list remains unchanged.    |
-| `updateBy`       | `(key: string \| undefined \| null, value: any, updateFn: (item: T) => T) => void` | Updates the **first** item where `item[key]` strictly equals `value` (or `item === value` if `key` is null/undefined) using an immutable `updateFn`. If no match is found, the list remains unchanged. |
-| `updateManyBy`   | `(key: string \| undefined \| null, value: any, updateFn: (item: T) => T) => void` | Updates **all** items where `item[key]` strictly equals `value` (or `item === value` if `key` is null/undefined) using an immutable `updateFn`. If no matches are found, the list remains unchanged. |
-| `clearList`      | `() => void`                                                | Removes all items from the list, setting it to an empty array.                                                                           |
-| `setList`        | `(newList: T[] \| ((currentList: T[]) => T[])) => void`     | Replaces the entire list array, similar to the standard `useState` setter. Accepts a new array or a function updater.                 |
-| `findItemBy`     | `(key: string \| undefined \| null, value: any) => T \| undefined` | Finds and returns the **first** item where `item[key]` strictly equals `value`. If `key` is `undefined` or `null`, finds the first item where `item` strictly equals `value`. Does not modify the list. Returns `undefined` if not found. |
-| `findItemsBy`    | `(key: string \| undefined \| null, value: any) => T[]`       | Finds and returns **all** items where `item[key]` strictly equals `value`. If `key` is `undefined` or `null`, finds all items where `item` strictly equals `value`. Does not modify the list. Returns an empty array if no matches are found. |
-| `count`          | `(predicate?: (item: T) => boolean) => number`              | Returns the total number of items in the list, or the count of items matching an optional `predicate`. Does not modify the list.       |
-| `toggle`         | `(item: T, key?: string \| undefined \| null) => void`      | Adds an item if it's not present, or removes it if it is, based on an optional key or reference comparison. |
-| `move`           | `(fromIndex: number, toIndex: number) => void`              | Moves an item from `fromIndex` to `toIndex` immutably. If indices are out of bounds or identical, the list remains unchanged. |
-| `sort`           | `(compareFn?: (a: T, b: T) => number) => void`              | Sorts the list immutably using an optional comparison function. |
-| `shuffle`        | `() => void`                                                | Randomly reorders the list items immutably. |
+| Property       | Type                                                                               | Description                                                                                                                                                                                                                                     |
+| -------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list`         | `T[]`                                                                              | The current array state.                                                                                                                                                                                                                        |
+| `addItem`      | `(item: T) => void`                                                                | Adds an `item` to the end of the array.                                                                                                                                                                                                         |
+| `insert`       | `(index: number, item: T) => void`                                                 | Inserts an `item` at the specified `index`. If the index is out of bounds, the item is added to the beginning (index < 0) or end (index > length).                                                                                              |
+| `insertMany`   | `(items: T[]) => void`                                                             | Adds multiple `items` to the end of the array. Does nothing if input is not an array or is empty.                                                                                                                                               |
+| `removeByIdx`  | `(index: number) => void`                                                          | Removes the item at the specified `index`. If the index is out of bounds, the list remains unchanged.                                                                                                                                           |
+| `removeBy`     | `(key: string \| undefined \| null, value: any) => void`                           | Removes the **first** item where `item[key]` strictly equals `value`. If `key` is `undefined` or `null`, removes the first item where `item` strictly equals `value` (useful for primitives). If no match is found, the list remains unchanged. |
+| `removeManyBy` | `(key: string \| undefined \| null, value: any) => void`                           | Removes **all** items where `item[key]` strictly equals `value`. If `key` is `undefined` or `null`, removes all items where `item` strictly equals `value` (useful for primitives). If no match is found, the list remains unchanged.           |
+| `updateByIdx`  | `(index: number, updateFn: (item: T) => T) => void`                                | Updates the item at the specified `index` using an immutable `updateFn`. If the index is out of bounds, the list remains unchanged.                                                                                                             |
+| `updateBy`     | `(key: string \| undefined \| null, value: any, updateFn: (item: T) => T) => void` | Updates the **first** item where `item[key]` strictly equals `value` (or `item === value` if `key` is null/undefined) using an immutable `updateFn`. If no match is found, the list remains unchanged.                                          |
+| `updateManyBy` | `(key: string \| undefined \| null, value: any, updateFn: (item: T) => T) => void` | Updates **all** items where `item[key]` strictly equals `value` (or `item === value` if `key` is null/undefined) using an immutable `updateFn`. If no matches are found, the list remains unchanged.                                            |
+| `clearList`    | `() => void`                                                                       | Removes all items from the list, setting it to an empty array.                                                                                                                                                                                  |
+| `setList`      | `(newList: T[] \| ((currentList: T[]) => T[])) => void`                            | Replaces the entire list array, similar to the standard `useState` setter. Accepts a new array or a function updater.                                                                                                                           |
+| `findItemBy`   | `(key: string \| undefined \| null, value: any) => T \| undefined`                 | Finds and returns the **first** item where `item[key]` strictly equals `value`. If `key` is `undefined` or `null`, finds the first item where `item` strictly equals `value`. Does not modify the list. Returns `undefined` if not found.       |
+| `findItemsBy`  | `(key: string \| undefined \| null, value: any) => T[]`                            | Finds and returns **all** items where `item[key]` strictly equals `value`. If `key` is `undefined` or `null`, finds all items where `item` strictly equals `value`. Does not modify the list. Returns an empty array if no matches are found.   |
+| `count`        | `(predicate?: (item: T) => boolean) => number`                                     | Returns the total number of items in the list, or the count of items matching an optional `predicate`. Does not modify the list.                                                                                                                |
+| `toggle`       | `(item: T, key?: string \| undefined \| null) => void`                             | Adds an item if it's not present, or removes it if it is, based on an optional key or reference comparison.                                                                                                                                     |
+| `move`         | `(fromIndex: number, toIndex: number) => void`                                     | Moves an item from `fromIndex` to `toIndex` immutably. If indices are out of bounds or identical, the list remains unchanged.                                                                                                                   |
+| `sort`         | `(compareFn?: (a: T, b: T) => number) => void`                                     | Sorts the list immutably using an optional comparison function.                                                                                                                                                                                 |
+| `shuffle`      | `() => void`                                                                       | Randomly reorders the list items immutably.                                                                                                                                                                                                     |
+| `swap`         | `(indexA: number, indexB: number) => void`                                         | Swaps two items in the list immutably based on their indices.                                                                                                                                                                                   |
 
-***
+---
 
 ## ♿ Accessibility & Performance
 
 All components follow accessibility best practices:
 
-* ✅ `Dialog` uses proper ARIA roles and keyboard focus control.
-* ✅ `Input` supports labeling, aria attributes, and datalists.
-* ✅ `LazyRender` and `Observer` use `IntersectionObserver` to optimize rendering.
+-   ✅ `Dialog` uses proper ARIA roles and keyboard focus control.
+-   ✅ `Input` supports labeling, aria attributes, and datalists.
+-   ✅ `LazyRender` and `Observer` use `IntersectionObserver` to optimize rendering.
 
-***
+---
 
 ## ❓ FAQ
 
@@ -1109,7 +1140,7 @@ A: Yes, all components are compatible with SSR environments.
 **Q: How can I report a bug or request a new feature?**\
 A: Open an issue on the [GitHub repo](https://github.com/galiprandi/react-tools/issues).
 
-***
+---
 
 ## 📄 License
 

--- a/lib/hooks/useList.test.ts
+++ b/lib/hooks/useList.test.ts
@@ -735,7 +735,9 @@ describe('useList', () => {
         })
 
         it('should remove a primitive item if it is in the list', () => {
-            const { result } = renderHook(() => useList<string>(['a', 'b', 'c']))
+            const { result } = renderHook(() =>
+                useList<string>(['a', 'b', 'c']),
+            )
             act(() => {
                 result.current.toggle('b')
             })
@@ -768,7 +770,10 @@ describe('useList', () => {
             act(() => {
                 result.current.toggle({ id: 2, name: 'other' }, 'id')
             })
-            expect(result.current.list).toEqual([item1, { id: 2, name: 'other' }])
+            expect(result.current.list).toEqual([
+                item1,
+                { id: 2, name: 'other' },
+            ])
         })
 
         it('should remove an object if it is in the list (by key)', () => {
@@ -925,6 +930,65 @@ describe('useList', () => {
                 result.current.shuffle()
             })
             expect(result.current.list).toEqual([1])
+        })
+    })
+
+    describe('swap', () => {
+        it('should swap two items in the list', () => {
+            const { result } = renderHook(() => useList(['a', 'b', 'c']))
+            act(() => {
+                result.current.swap(0, 2)
+            })
+            expect(result.current.list).toEqual(['c', 'b', 'a'])
+        })
+
+        it('should return a new list instance', () => {
+            const initialList = ['a', 'b']
+            const { result } = renderHook(() => useList(initialList))
+            const originalList = result.current.list
+            act(() => {
+                result.current.swap(0, 1)
+            })
+            expect(result.current.list).not.toBe(originalList)
+        })
+
+        it('should do nothing if indices are identical', () => {
+            const initialList = ['a', 'b', 'c']
+            const { result } = renderHook(() => useList(initialList))
+            const originalList = result.current.list
+            act(() => {
+                result.current.swap(1, 1)
+            })
+            expect(result.current.list).toEqual(initialList)
+            expect(result.current.list).toBe(originalList)
+        })
+
+        it('should do nothing if indexA is out of bounds', () => {
+            const initialList = ['a', 'b', 'c']
+            const { result } = renderHook(() => useList(initialList))
+            const originalList = result.current.list
+            act(() => {
+                result.current.swap(-1, 1)
+            })
+            expect(result.current.list).toBe(originalList)
+            act(() => {
+                result.current.swap(3, 1)
+            })
+            expect(result.current.list).toBe(originalList)
+        })
+
+        it('should do nothing if indexB is out of bounds', () => {
+            const initialList = ['a', 'b', 'c']
+            const { result } = renderHook(() => useList(initialList))
+            const originalList = result.current.list
+            act(() => {
+                result.current.swap(1, -1)
+            })
+            expect(result.current.list).toBe(originalList)
+            act(() => {
+                result.current.swap(1, 3)
+            })
+            expect(result.current.list).toBe(originalList)
         })
     })
 })

--- a/lib/hooks/useList.tsx
+++ b/lib/hooks/useList.tsx
@@ -274,6 +274,30 @@ export function useList<T>(initialList: T[] = []): UseListReturn<T> {
         })
     }, [setListCallback])
 
+    const swap = useCallback(
+        (indexA: number, indexB: number) => {
+            setListCallback((currentList) => {
+                if (
+                    indexA < 0 ||
+                    indexA >= currentList.length ||
+                    indexB < 0 ||
+                    indexB >= currentList.length ||
+                    indexA === indexB
+                ) {
+                    return currentList
+                }
+
+                const newList = [...currentList]
+                ;[newList[indexA], newList[indexB]] = [
+                    newList[indexB],
+                    newList[indexA],
+                ]
+                return newList
+            })
+        },
+        [setListCallback],
+    )
+
     return {
         list,
         addItem,
@@ -295,6 +319,7 @@ export function useList<T>(initialList: T[] = []): UseListReturn<T> {
         move,
         sort,
         shuffle,
+        swap,
     }
 }
 
@@ -351,4 +376,6 @@ interface UseListReturn<T> {
     sort: (compareFn?: (a: T, b: T) => number) => void
     /** Randomly reorders the list items immutably. */
     shuffle: () => void
+    /** Swaps two items in the list immutably based on their indices. */
+    swap: (indexA: number, indexB: number) => void
 }

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -5,33 +5,52 @@ This directory contains a **playground/development site** for the `@galiprandi/r
 ## Important Notes
 
 ### Dependency-Free Library
+
 The `@galiprandi/react-tools` library itself is **dependency-free**. This is a core design principle to ensure:
-- Minimal bundle size impact for consumers
-- No version conflicts with consumer dependencies
-- Maximum flexibility for users to choose their own dependencies
+
+-   Minimal bundle size impact for consumers
+-   No version conflicts with consumer dependencies
+-   Maximum flexibility for users to choose their own dependencies
 
 ### This Playground's Dependencies
+
 The playground site in this directory **may include dependencies** that are **NOT** part of the library:
-- **Pico CSS**: Used for styling this playground via CDN (not bundled with the library)
-- **React Router**: Previously used for navigation in this playground (not part of the library)
-- **ReactMarkdown**: Previously used for rendering markdown in this playground (not part of the library)
+
+-   **Pico CSS**: Used for styling this playground via CDN (not bundled with the library)
+-   **React Router**: Previously used for navigation in this playground (not part of the library)
+-   **ReactMarkdown**: Previously used for rendering markdown in this playground (not part of the library)
 
 **These dependencies are NOT included in the published library package.**
 
 ### Styling
+
 This playground uses **Pico CSS** (class-less CSS framework) loaded via CDN:
+
 ```html
 <link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.slate.min.css"
->
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.slate.min.css"
+/>
 ```
 
 This is **only for the playground** and is **not** required or bundled with the library.
 
 ## Library vs Playground
 
-- **Library (`lib/`)**: Contains the actual hooks and components that are published. No external dependencies.
-- **Playground (`src/`)**: Contains demo applications and examples that showcase the library. May use external dependencies for demonstration purposes.
+-   **Library (`lib/`)**: Contains the actual hooks and components that are published. No external dependencies.
+-   **Playground (`src/`)**: Contains demo applications and examples that showcase the library. May use external dependencies for demonstration purposes.
 
 When using `@galiprandi/react-tools` in your own project, you will only get the dependency-free hooks and components from the library.
+
+## Development Standards
+
+### Documentation Alignment
+
+It is critical to keep `README.md`, unit tests, and playground pages (`src/pages/`) aligned with the actual library functionality (`lib/`).
+
+-   When adding a new method to a hook, update its interface, implementation, unit tests, and the corresponding example page.
+-   Always update the documentation table in `README.md` for any public API changes.
+
+### Immutable Updates
+
+Ensure all state updates in hooks (like `useList`) are immutable and optimized. Return the current state reference for redundant operations to avoid unnecessary re-renders.

--- a/src/pages/list/useListPage.tsx
+++ b/src/pages/list/useListPage.tsx
@@ -7,24 +7,45 @@ interface Item {
 }
 
 export const UseListPage = () => {
-    const { list, addItem, insert, insertMany, removeByIdx, removeBy, removeManyBy, updateByIdx, updateBy, updateManyBy, clearList, setList, findItemBy, findItemsBy, count, toggle, move, sort, shuffle } = useList<Item>([
+    const {
+        list,
+        addItem,
+        insert,
+        insertMany,
+        removeByIdx,
+        removeBy,
+        removeManyBy,
+        updateByIdx,
+        updateBy,
+        updateManyBy,
+        clearList,
+        setList,
+        findItemBy,
+        findItemsBy,
+        count,
+        toggle,
+        move,
+        sort,
+        shuffle,
+        swap,
+    } = useList<Item>([
         { id: 1, name: 'Item 1', value: 10 },
         { id: 2, name: 'Item 2', value: 20 },
         { id: 3, name: 'Item 3', value: 30 },
     ])
 
     const handleAddItem = () => {
-        const newId = Math.max(...list.map(i => i.id), 0) + 1
+        const newId = Math.max(...list.map((i) => i.id), 0) + 1
         addItem({ id: newId, name: `Item ${newId}`, value: newId * 10 })
     }
 
     const handleInsert = () => {
-        const newId = Math.max(...list.map(i => i.id), 0) + 1
+        const newId = Math.max(...list.map((i) => i.id), 0) + 1
         insert(1, { id: newId, name: `Inserted ${newId}`, value: newId * 10 })
     }
 
     const handleInsertMany = () => {
-        const maxId = Math.max(...list.map(i => i.id), 0)
+        const maxId = Math.max(...list.map((i) => i.id), 0)
         insertMany([
             { id: maxId + 1, name: 'Bulk 1', value: 100 },
             { id: maxId + 2, name: 'Bulk 2', value: 200 },
@@ -44,15 +65,25 @@ export const UseListPage = () => {
     }
 
     const handleUpdateByIdx = () => {
-        if (list.length > 0) updateByIdx(0, (item) => ({ ...item, name: 'Updated ' + item.name }))
+        if (list.length > 0)
+            updateByIdx(0, (item) => ({
+                ...item,
+                name: 'Updated ' + item.name,
+            }))
     }
 
     const handleUpdateBy = () => {
-        updateBy('name', 'Item 2', (item) => ({ ...item, value: item.value * 2 }))
+        updateBy('name', 'Item 2', (item) => ({
+            ...item,
+            value: item.value * 2,
+        }))
     }
 
     const handleUpdateManyBy = () => {
-        updateManyBy('value', 20, (item) => ({ ...item, name: 'Updated ' + item.name }))
+        updateManyBy('value', 20, (item) => ({
+            ...item,
+            name: 'Updated ' + item.name,
+        }))
     }
 
     const handleClear = () => {
@@ -79,6 +110,10 @@ export const UseListPage = () => {
         shuffle()
     }
 
+    const handleSwap = () => {
+        if (list.length >= 2) swap(0, 1)
+    }
+
     return (
         <main>
             <article>
@@ -90,32 +125,86 @@ export const UseListPage = () => {
                 <section>
                     <h3>Documentation</h3>
                     <article>
-                        <p>The <code>useList</code> hook simplifies managing array state with immutable helper methods.</p>
-                        <p><strong>Parameters:</strong></p>
+                        <p>
+                            The <code>useList</code> hook simplifies managing
+                            array state with immutable helper methods.
+                        </p>
+                        <p>
+                            <strong>Parameters:</strong>
+                        </p>
                         <ul>
-                            <li><code>initialList</code>: T[] - Initial array state (default: [])</li>
+                            <li>
+                                <code>initialList</code>: T[] - Initial array
+                                state (default: [])
+                            </li>
                         </ul>
-                        <p><strong>Returns:</strong></p>
+                        <p>
+                            <strong>Returns:</strong>
+                        </p>
                         <ul>
-                            <li><code>list</code>: T[] - Current array state</li>
-                            <li><code>addItem</code>: Add item to end</li>
-                            <li><code>insert</code>: Insert at index</li>
-                            <li><code>insertMany</code>: Add multiple items</li>
-                            <li><code>removeByIdx</code>: Remove by index</li>
-                            <li><code>removeBy</code>: Remove first matching item</li>
-                            <li><code>removeManyBy</code>: Remove all matching items</li>
-                            <li><code>updateByIdx</code>: Update by index</li>
-                            <li><code>updateBy</code>: Update first matching</li>
-                            <li><code>updateManyBy</code>: Update all matching</li>
-                            <li><code>clearList</code>: Clear all items</li>
-                            <li><code>setList</code>: Replace entire list</li>
-                            <li><code>findItemBy</code>: Find first matching</li>
-                            <li><code>findItemsBy</code>: Find all matching</li>
-                            <li><code>count</code>: Count items</li>
-                            <li><code>toggle</code>: Add if not present, remove if is</li>
-                            <li><code>move</code>: Move item</li>
-                            <li><code>sort</code>: Sort list</li>
-                            <li><code>shuffle</code>: Randomly reorder</li>
+                            <li>
+                                <code>list</code>: T[] - Current array state
+                            </li>
+                            <li>
+                                <code>addItem</code>: Add item to end
+                            </li>
+                            <li>
+                                <code>insert</code>: Insert at index
+                            </li>
+                            <li>
+                                <code>insertMany</code>: Add multiple items
+                            </li>
+                            <li>
+                                <code>removeByIdx</code>: Remove by index
+                            </li>
+                            <li>
+                                <code>removeBy</code>: Remove first matching
+                                item
+                            </li>
+                            <li>
+                                <code>removeManyBy</code>: Remove all matching
+                                items
+                            </li>
+                            <li>
+                                <code>updateByIdx</code>: Update by index
+                            </li>
+                            <li>
+                                <code>updateBy</code>: Update first matching
+                            </li>
+                            <li>
+                                <code>updateManyBy</code>: Update all matching
+                            </li>
+                            <li>
+                                <code>clearList</code>: Clear all items
+                            </li>
+                            <li>
+                                <code>setList</code>: Replace entire list
+                            </li>
+                            <li>
+                                <code>findItemBy</code>: Find first matching
+                            </li>
+                            <li>
+                                <code>findItemsBy</code>: Find all matching
+                            </li>
+                            <li>
+                                <code>count</code>: Count items
+                            </li>
+                            <li>
+                                <code>toggle</code>: Add if not present, remove
+                                if is
+                            </li>
+                            <li>
+                                <code>move</code>: Move item
+                            </li>
+                            <li>
+                                <code>sort</code>: Sort list
+                            </li>
+                            <li>
+                                <code>shuffle</code>: Randomly reorder
+                            </li>
+                            <li>
+                                <code>swap</code>: Swap two items
+                            </li>
                         </ul>
                     </article>
                 </section>
@@ -124,26 +213,68 @@ export const UseListPage = () => {
                 <section>
                     <h3>Live Example</h3>
                     <article>
-                        <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+                        <div
+                            style={{
+                                display: 'flex',
+                                gap: '10px',
+                                flexWrap: 'wrap',
+                            }}
+                        >
                             <button onClick={handleAddItem}>Add Item</button>
-                            <button onClick={handleInsert}>Insert at Index 1</button>
-                            <button onClick={handleInsertMany}>Insert Many</button>
-                            <button onClick={handleRemoveByIdx} className="secondary">Remove By Index 0</button>
-                            <button onClick={handleRemoveBy} className="secondary">Remove By Name &apos;Item 1&apos;</button>
-                            <button onClick={handleRemoveManyBy} className="secondary">Remove Many By Value 10</button>
-                            <button onClick={handleUpdateByIdx}>Update Index 0</button>
-                            <button onClick={handleUpdateBy}>Update &apos;Item 2&apos;</button>
-                            <button onClick={handleUpdateManyBy}>Update Many Value 20</button>
-                            <button onClick={handleToggle}>Toggle Item 1</button>
-                            <button onClick={handleMove}>Move First to Last</button>
+                            <button onClick={handleInsert}>
+                                Insert at Index 1
+                            </button>
+                            <button onClick={handleInsertMany}>
+                                Insert Many
+                            </button>
+                            <button
+                                onClick={handleRemoveByIdx}
+                                className="secondary"
+                            >
+                                Remove By Index 0
+                            </button>
+                            <button
+                                onClick={handleRemoveBy}
+                                className="secondary"
+                            >
+                                Remove By Name &apos;Item 1&apos;
+                            </button>
+                            <button
+                                onClick={handleRemoveManyBy}
+                                className="secondary"
+                            >
+                                Remove Many By Value 10
+                            </button>
+                            <button onClick={handleUpdateByIdx}>
+                                Update Index 0
+                            </button>
+                            <button onClick={handleUpdateBy}>
+                                Update &apos;Item 2&apos;
+                            </button>
+                            <button onClick={handleUpdateManyBy}>
+                                Update Many Value 20
+                            </button>
+                            <button onClick={handleToggle}>
+                                Toggle Item 1
+                            </button>
+                            <button onClick={handleMove}>
+                                Move First to Last
+                            </button>
                             <button onClick={handleSort}>Sort by Value</button>
                             <button onClick={handleShuffle}>Shuffle</button>
+                            <button onClick={handleSwap}>
+                                Swap Index 0 & 1
+                            </button>
                             <button onClick={handleSetList}>Reset List</button>
-                            <button onClick={handleClear} className="secondary">Clear All</button>
+                            <button onClick={handleClear} className="secondary">
+                                Clear All
+                            </button>
                         </div>
 
                         <details>
-                            <summary>Current List ({list.length} items)</summary>
+                            <summary>
+                                Current List ({list.length} items)
+                            </summary>
                             <pre>
                                 <code>{JSON.stringify(list, null, 2)}</code>
                             </pre>
@@ -152,13 +283,29 @@ export const UseListPage = () => {
                         <details>
                             <summary>Query Results</summary>
                             <pre>
-                                <code>{JSON.stringify({
-                                    findItemBy: findItemBy('name', 'Item 2'),
-                                    findItemsBy_value20: findItemsBy('value', 20),
-                                    count_total: count(),
-                                    count_value_gt_15: count(item => item.value > 15),
-                                    count_value_gt_100: count(item => item.value > 100)
-                                }, null, 2)}</code>
+                                <code>
+                                    {JSON.stringify(
+                                        {
+                                            findItemBy: findItemBy(
+                                                'name',
+                                                'Item 2',
+                                            ),
+                                            findItemsBy_value20: findItemsBy(
+                                                'value',
+                                                20,
+                                            ),
+                                            count_total: count(),
+                                            count_value_gt_15: count(
+                                                (item) => item.value > 15,
+                                            ),
+                                            count_value_gt_100: count(
+                                                (item) => item.value > 100,
+                                            ),
+                                        },
+                                        null,
+                                        2,
+                                    )}
+                                </code>
                             </pre>
                         </details>
 


### PR DESCRIPTION
I have added a new `swap` method to the `useList` hook. This method allows users to exchange the positions of two items in the list immutably by providing their indices.

Key changes:
- Implemented `swap(indexA, indexB)` in `lib/hooks/useList.tsx`.
- Updated `UseListReturn` interface in `lib/hooks/useList.tsx`.
- Added unit tests for `swap` in `lib/hooks/useList.test.ts`, covering successful swaps, out-of-bounds indices, and identical indices.
- Updated the `useList` documentation table in `README.md` to include the new `swap` method.

The implementation follows the library's existing patterns for immutable state management and provides a clean, dependency-free enhancement to the `useList` hook. All tests passed, and the build was verified successfully.

---
*PR created automatically by Jules for task [169683896239996340](https://jules.google.com/task/169683896239996340) started by @galiprandi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added swap capability to the list hook, letting users exchange two items immutably.
  * UI: Added a "Swap Index 0 & 1" button to demo the swap action.

* **Tests**
  * Added tests covering swap behavior, immutability, and boundary/no-op cases.

* **Documentation**
  * Updated playground and project notes to document swap behavior and immutable update guidelines; added changelog entry about optimized state-update guards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galiprandi/react-tools/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->