### PR TITLE
⚡ Spark: useList.swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1082,6 +1082,7 @@ An object containing the current array state (`list`) and helper functions to mo
 | `move`           | `(fromIndex: number, toIndex: number) => void`              | Moves an item from `fromIndex` to `toIndex` immutably. If indices are out of bounds or identical, the list remains unchanged. |
 | `sort`           | `(compareFn?: (a: T, b: T) => number) => void`              | Sorts the list immutably using an optional comparison function. |
 | `shuffle`        | `() => void`                                                | Randomly reorders the list items immutably. |
+| `swap`           | `(indexA: number, indexB: number) => void`                  | Swaps two items in the list immutably based on their indices. |
 
 ***
 

--- a/lib/hooks/useList.test.ts
+++ b/lib/hooks/useList.test.ts
@@ -927,4 +927,52 @@ describe('useList', () => {
             expect(result.current.list).toEqual([1])
         })
     })
+
+    describe('swap', () => {
+        it('should swap two items in the list', () => {
+            const { result } = renderHook(() => useList(['a', 'b', 'c']))
+            act(() => {
+                result.current.swap(0, 2)
+            })
+            expect(result.current.list).toEqual(['c', 'b', 'a'])
+        })
+
+        it('should do nothing if indices are identical', () => {
+            const initialList = ['a', 'b', 'c']
+            const { result } = renderHook(() => useList(initialList))
+            const originalList = result.current.list
+            act(() => {
+                result.current.swap(1, 1)
+            })
+            expect(result.current.list).toEqual(initialList)
+            expect(result.current.list).toBe(originalList)
+        })
+
+        it('should do nothing if any index is out of bounds', () => {
+            const initialList = ['a', 'b', 'c']
+            const { result } = renderHook(() => useList(initialList))
+            const originalList = result.current.list
+
+            act(() => {
+                result.current.swap(-1, 1)
+            })
+            expect(result.current.list).toBe(originalList)
+
+            act(() => {
+                result.current.swap(1, 3)
+            })
+            expect(result.current.list).toBe(originalList)
+        })
+
+        it('should return a new list instance on successful swap', () => {
+            const initialList = ['a', 'b']
+            const { result } = renderHook(() => useList(initialList))
+            const originalList = result.current.list
+            act(() => {
+                result.current.swap(0, 1)
+            })
+            expect(result.current.list).toEqual(['b', 'a'])
+            expect(result.current.list).not.toBe(originalList)
+        })
+    })
 })

--- a/lib/hooks/useList.tsx
+++ b/lib/hooks/useList.tsx
@@ -274,6 +274,30 @@ export function useList<T>(initialList: T[] = []): UseListReturn<T> {
         })
     }, [setListCallback])
 
+    const swap = useCallback(
+        (indexA: number, indexB: number) => {
+            setListCallback((currentList) => {
+                if (
+                    indexA < 0 ||
+                    indexA >= currentList.length ||
+                    indexB < 0 ||
+                    indexB >= currentList.length ||
+                    indexA === indexB
+                ) {
+                    return currentList
+                }
+
+                const newList = [...currentList]
+                ;[newList[indexA], newList[indexB]] = [
+                    newList[indexB],
+                    newList[indexA],
+                ]
+                return newList
+            })
+        },
+        [setListCallback],
+    )
+
     return {
         list,
         addItem,
@@ -295,6 +319,7 @@ export function useList<T>(initialList: T[] = []): UseListReturn<T> {
         move,
         sort,
         shuffle,
+        swap,
     }
 }
 
@@ -351,4 +376,6 @@ interface UseListReturn<T> {
     sort: (compareFn?: (a: T, b: T) => number) => void
     /** Randomly reorders the list items immutably. */
     shuffle: () => void
+    /** Swaps two items in the list immutably based on their indices. */
+    swap: (indexA: number, indexB: number) => void
 }


### PR DESCRIPTION
💡 **What:** Added a new `swap` method to the `useList` hook.
🎯 **Why:** To provide a convenient and immutable way to exchange positions of two elements in a list, complementing `move`, `sort`, and `shuffle`.
📦 **What it adds:** A `swap(indexA, indexB)` function to the hook's return object and updated the TypeScript interface.
🚀 **How to use:**
```tsx
const { list, swap } = useList(['a', 'b', 'c']);
swap(0, 2); // list becomes ['c', 'b', 'a']
```
♻️ **Deps Free:** Confirmation no new dependencies were added.
🎨 **Harmony:** Follows existing patterns in `useList` and handles edge cases (out-of-bounds, identical indices) by returning the original list reference.

---
*PR created automatically by Jules for task [1018702907278057832](https://jules.google.com/task/1018702907278057832) started by @galiprandi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `useList` hook now includes a `swap()` method that immutably swaps two items in the list by their indices. Handles edge cases like identical indices and out-of-bounds gracefully.

* **Documentation**
  * Updated README documentation to describe the new `swap()` helper method.

* **Tests**
  * Added comprehensive test coverage for the swap functionality, including edge cases and no-op scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galiprandi/react-tools/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->