### PR TITLE
⚡ Spark: enhance useList.sort with key-based and order-aware sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1080,7 +1080,7 @@ An object containing the current array state (`list`) and helper functions to mo
 | `count`          | `(predicate?: (item: T) => boolean) => number`              | Returns the total number of items in the list, or the count of items matching an optional `predicate`. Does not modify the list.       |
 | `toggle`         | `(item: T, key?: string \| undefined \| null) => void`      | Adds an item if it's not present, or removes it if it is, based on an optional key or reference comparison. |
 | `move`           | `(fromIndex: number, toIndex: number) => void`              | Moves an item from `fromIndex` to `toIndex` immutably. If indices are out of bounds or identical, the list remains unchanged. |
-| `sort`           | `(compareFn?: (a: T, b: T) => number) => void`              | Sorts the list immutably using an optional comparison function. |
+| `sort`           | `(keyOrCompareFn?: string \| ((a: T, b: T) => number) \| null, order?: 'asc' \| 'desc') => void` | Sorts the list immutably using an optional key or comparison function, and an optional sort order. |
 | `shuffle`        | `() => void`                                                | Randomly reorders the list items immutably. |
 | `swap`           | `(indexA: number, indexB: number) => void`                  | Swaps two items in the list immutably based on their indices. |
 

--- a/lib/hooks/useList.test.ts
+++ b/lib/hooks/useList.test.ts
@@ -840,12 +840,56 @@ describe('useList', () => {
     })
 
     describe('sort', () => {
-        it('should sort the list with default sort order', () => {
+        it('should sort the list with default sort order (ascending)', () => {
             const { result } = renderHook(() => useList(['b', 'c', 'a']))
             act(() => {
                 result.current.sort()
             })
             expect(result.current.list).toEqual(['a', 'b', 'c'])
+        })
+
+        it('should sort the list in descending order for primitives', () => {
+            const { result } = renderHook(() => useList(['b', 'c', 'a']))
+            act(() => {
+                result.current.sort(null, 'desc')
+            })
+            expect(result.current.list).toEqual(['c', 'b', 'a'])
+        })
+
+        it('should sort the list by key in ascending order', () => {
+            const { result } = renderHook(() =>
+                useList([
+                    { id: 3, name: 'c' },
+                    { id: 1, name: 'a' },
+                    { id: 2, name: 'b' },
+                ]),
+            )
+            act(() => {
+                result.current.sort('id')
+            })
+            expect(result.current.list).toEqual([
+                { id: 1, name: 'a' },
+                { id: 2, name: 'b' },
+                { id: 3, name: 'c' },
+            ])
+        })
+
+        it('should sort the list by key in descending order', () => {
+            const { result } = renderHook(() =>
+                useList([
+                    { id: 3, name: 'c' },
+                    { id: 1, name: 'a' },
+                    { id: 2, name: 'b' },
+                ]),
+            )
+            act(() => {
+                result.current.sort('name', 'desc')
+            })
+            expect(result.current.list).toEqual([
+                { id: 3, name: 'c' },
+                { id: 2, name: 'b' },
+                { id: 1, name: 'a' },
+            ])
         })
 
         it('should sort the list with a custom compare function', () => {

--- a/lib/hooks/useList.tsx
+++ b/lib/hooks/useList.tsx
@@ -257,8 +257,29 @@ export function useList<T>(initialList: T[] = []): UseListReturn<T> {
     )
 
     const sort = useCallback(
-        (compareFn?: (a: T, b: T) => number) => {
-            setListCallback((currentList) => [...currentList].sort(compareFn))
+        (
+            keyOrCompareFn?: string | ((a: T, b: T) => number) | null,
+            order: 'asc' | 'desc' = 'asc',
+        ) => {
+            setListCallback((currentList) => {
+                const newList = [...currentList]
+                if (typeof keyOrCompareFn === 'function') {
+                    return newList.sort(keyOrCompareFn)
+                }
+
+                return newList.sort((a, b) => {
+                    const valA = getValueToCompare(a, keyOrCompareFn)
+                    const valB = getValueToCompare(b, keyOrCompareFn)
+
+                    if (valA === valB) return 0
+
+                    if (valA === undefined || valA === null) return 1
+                    if (valB === undefined || valB === null) return -1
+
+                    const result = valA < valB ? -1 : 1
+                    return order === 'asc' ? result : -result
+                })
+            })
         },
         [setListCallback],
     )
@@ -372,8 +393,11 @@ interface UseListReturn<T> {
     toggle: (item: T, key?: string | undefined | null) => void
     /** Moves an item from one index to another immutably. */
     move: (fromIndex: number, toIndex: number) => void
-    /** Sorts the list immutably using an optional comparison function. */
-    sort: (compareFn?: (a: T, b: T) => number) => void
+    /** Sorts the list immutably using an optional key or comparison function, and an optional sort order. */
+    sort: (
+        keyOrCompareFn?: string | ((a: T, b: T) => number) | null,
+        order?: 'asc' | 'desc',
+    ) => void
     /** Randomly reorders the list items immutably. */
     shuffle: () => void
     /** Swaps two items in the list immutably based on their indices. */


### PR DESCRIPTION
💡 **What:** Enhanced the `sort` method in the `useList` hook.
🎯 **Why:** Users often need to sort lists of objects by specific keys or change the sort order without writing complex comparison functions every time.
📦 **What it adds:**
- `sort(key, order)`: Sort by a specific object key in 'asc' (default) or 'desc' order.
- `sort(null, order)`: Sort primitives in 'asc' or 'desc' order.
- Full backward compatibility for `sort(compareFn)`.
🚀 **How to use:**
```tsx
const { list, sort } = useList([{id: 2, name: 'B'}, {id: 1, name: 'A'}]);
sort('name', 'asc'); // [{id: 1, name: 'A'}, {id: 2, name: 'B'}]
sort('id', 'desc'); // [{id: 2, name: 'B'}, {id: 1, name: 'A'}]
```
♻️ **Deps Free:** Uses only existing internal utilities and React hooks.
🎨 **Harmony:** Follows the established pattern in `useList` (like `removeBy`, `toggle`) of using an optional key for object operations while supporting primitives when the key is omitted.

---
*PR created automatically by Jules for task [4339735508399009431](https://jules.google.com/task/4339735508399009431) started by @galiprandi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced list sorting with support for sorting by object property keys alongside custom comparison functions
  * Added configurable sort order parameter for ascending and descending sort directions

* **Documentation**
  * Updated API documentation reflecting new sorting capabilities

* **Tests**
  * Expanded test coverage for sorting scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galiprandi/react-tools/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->