### PR TITLE
⚡ Spark: useDebounce default delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,10 +938,10 @@ const debouncedSearch = useDebounce(searchTerm, 500);
 
 **Props**
 
-| Parameter     | Type      | Description                    |
-|---------------|-----------|--------------------------------|
-| `value`       | `T`       | Value to debounce              |
-| `delay`       | `number`  | Delay in milliseconds          |
+| Parameter     | Type      | Description                               |
+|---------------|-----------|-------------------------------------------|
+| `value`       | `T`       | Value to debounce                         |
+| `delay`       | `number`  | Delay in milliseconds (default: `500`)    |
 
 **Returns**\
 Debounced version of the value (`T`).

--- a/lib/hooks/useDebounce.test.ts
+++ b/lib/hooks/useDebounce.test.ts
@@ -77,4 +77,31 @@ describe('useDebounce', () => {
         expect(spy).toHaveBeenCalled()
         spy.mockRestore()
     })
+
+    it('should use default delay of 500ms when no delay is provided', () => {
+        const { result, rerender } = renderHook(
+            ({ val }) => useDebounce(val),
+            {
+                initialProps: { val: 'initial' },
+            },
+        )
+
+        expect(result.current).toBe('initial')
+
+        // Update value
+        rerender({ val: 'updated' })
+        expect(result.current).toBe('initial')
+
+        // Advance timers by 499ms
+        act(() => {
+            vi.advanceTimersByTime(499)
+        })
+        expect(result.current).toBe('initial')
+
+        // Advance timers to 500ms
+        act(() => {
+            vi.advanceTimersByTime(1)
+        })
+        expect(result.current).toBe('updated')
+    })
 })

--- a/lib/hooks/useDebounce.ts
+++ b/lib/hooks/useDebounce.ts
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react'
  * @template T
  * @param value - The value to debounce.
  * @param delay - The delay in milliseconds to debounce the value.
+ * @default 500
  * @returns The debounced value.
  *
  * @example
@@ -29,7 +30,7 @@ import { useEffect, useState } from 'react'
  * };
  * ```
  */
-export function useDebounce<T>(value: T, delay: number): T {
+export function useDebounce<T>(value: T, delay: number = 500): T {
     const [debouncedValue, setDebouncedValue] = useState<T>(value)
 
     useEffect(() => {


### PR DESCRIPTION
💡 **What:** Added a default delay of 500ms to the `useDebounce` hook.
🎯 **Why:** To harmonize the `useDebounce` interface with `useThrottle` and provide a sensible default for common use cases.
📦 **What it adds:** An optional `delay` parameter in `useDebounce` that defaults to 500ms.
🚀 **How to use:** `const debouncedValue = useDebounce(value); // defaults to 500ms`
♻️ **Deps Free:** Yes, uses only React's `useState` and `useEffect`.
🎨 **Harmony:** Matches the existing pattern in `useThrottle` and follows the library's philosophy of providing sensible defaults.

---
*PR created automatically by Jules for task [7852395757274156128](https://jules.google.com/task/7852395757274156128) started by @galiprandi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `useDebounce` hook now defaults to a 500ms delay when not explicitly specified.

* **Documentation**
  * Clarified default delay value in documentation.

* **Tests**
  * Added test coverage for default delay behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galiprandi/react-tools/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->