### PR TITLE
⚡ Spark: add reverse method to useList

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -17,3 +17,7 @@
 ## 2026-05-15 - [Render Prop Reload Pattern]
 **Learning:** Adding a `reload` function as an argument to render props in components that manage async state (`AsyncBlock`) provides a seamless way for users to implement manual refresh or retry logic without increasing component complexity.
 **Pattern:** Implement an internal `tick` state that triggers the core `useEffect` and expose a `reload` callback that increments it via the component's render functions.
+
+## 2026-05-20 - [No-op Optimizations in Immutable State]
+**Learning:** For list manipulation hooks, implementing no-op checks (returning the original state reference) for operations that would result in an identical array (e.g., reversing a single-item list or swapping out-of-bounds indices) prevents unnecessary React re-renders and improves performance.
+**Pattern:** Always check for edge cases where an operation results in no change and return the `currentList` reference immediately.

--- a/README.md
+++ b/README.md
@@ -1083,6 +1083,7 @@ An object containing the current array state (`list`) and helper functions to mo
 | `sort`           | `(keyOrCompareFn?: string \| ((a: T, b: T) => number) \| null, order?: 'asc' \| 'desc') => void` | Sorts the list immutably using an optional key or comparison function, and an optional sort order. |
 | `shuffle`        | `() => void`                                                | Randomly reorders the list items immutably. |
 | `swap`           | `(indexA: number, indexB: number) => void`                  | Swaps two items in the list immutably based on their indices. |
+| `reverse`         | `() => void`                                                | Reverses the order of the items in the list immutably. |
 
 ***
 

--- a/lib/hooks/useList.test.ts
+++ b/lib/hooks/useList.test.ts
@@ -1019,4 +1019,55 @@ describe('useList', () => {
             expect(result.current.list).not.toBe(originalList)
         })
     })
+
+    describe('reverse', () => {
+        it('should reverse the order of items in the list', () => {
+            const { result } = renderHook(() => useList(['a', 'b', 'c']))
+            act(() => {
+                result.current.reverse()
+            })
+            expect(result.current.list).toEqual(['c', 'b', 'a'])
+        })
+
+        it('should reverse a list of objects', () => {
+            const item1 = { id: 1 }
+            const item2 = { id: 2 }
+            const { result } = renderHook(() => useList([item1, item2]))
+            act(() => {
+                result.current.reverse()
+            })
+            expect(result.current.list).toEqual([item2, item1])
+        })
+
+        it('should do nothing and keep same reference for empty list', () => {
+            const { result } = renderHook(() => useList<number>([]))
+            const originalList = result.current.list
+            act(() => {
+                result.current.reverse()
+            })
+            expect(result.current.list).toEqual([])
+            expect(result.current.list).toBe(originalList)
+        })
+
+        it('should do nothing and keep same reference for single item list', () => {
+            const { result } = renderHook(() => useList(['a']))
+            const originalList = result.current.list
+            act(() => {
+                result.current.reverse()
+            })
+            expect(result.current.list).toEqual(['a'])
+            expect(result.current.list).toBe(originalList)
+        })
+
+        it('should return a new list instance when reversed', () => {
+            const initialList = ['a', 'b']
+            const { result } = renderHook(() => useList(initialList))
+            const originalList = result.current.list
+            act(() => {
+                result.current.reverse()
+            })
+            expect(result.current.list).toEqual(['b', 'a'])
+            expect(result.current.list).not.toBe(originalList)
+        })
+    })
 })

--- a/lib/hooks/useList.tsx
+++ b/lib/hooks/useList.tsx
@@ -29,27 +29,25 @@ function getValueToCompare<T>(item: T, key: string | undefined | null): any {
 export function useList<T>(initialList: T[] = []): UseListReturn<T> {
     const [list, setList] = useState<T[]>(initialList)
 
-    // CORRECCIÓN AQUÍ: Asegura que siempre se pase una NUEVA instancia a setList si no es un updater function
+    // Ensure a NEW instance is always passed to setList if it's not an updater function
     const setListCallback = useCallback(
         (newList: T[] | ((currentList: T[]) => T[])) => {
             if (typeof newList === 'function') {
                 setList((currentList) => {
                     const result = newList(currentList)
-                    // Si el updater retorna un array, asegúrate de que sea una *nueva* instancia para React
-                    // Si el resultado es el mismo array que currentList, setList optimizará y no re-renderizará.
-                    // Si el resultado es un *nuevo* array con el mismo contenido, setList *sí* re-renderizará.
-                    // Esto puede ser un debate de rendimiento vs. garantía de nueva instancia.
-                    // La forma más segura para testing (garantizar nueva instancia si *cualquier* cambio ocurrió)
-                    // y a menudo práctica es que los métodos (remove, update, add) *ya devuelvan* nuevas instancias cuando cambian.
-                    // Y que setListCallback simplemente pase el resultado.
-                    // ¡La corrección anterior ya hizo eso!
-                    // Simplemente pasemos el resultado del updater.
+                    // If the updater returns an array, ensure it is a *new* instance for React
+                    // If the result is the same array as currentList, setList will optimize and not re-render.
+                    // If the result is a *new* array with the same content, setList *will* re-render.
+                    // This can be a debate of performance vs. guaranteed new instance.
+                    // The safest way for testing (ensuring a new instance if *any* change occurred)
+                    // and often practical is that methods (remove, update, add) *already return* new instances when they change.
+                    // And that setListCallback simply passes the result.
                     return result // Pass the result directly
                 })
             } else {
-                // Si es un array directo, crea una *copia* para asegurar una nueva instancia
-                // Esto es lo que espera el test `should replace the list with a new array`.
-                setList([...newList]) // <--- Usamos spread para crear una copia
+                // If it's a direct array, create a *copy* to ensure a new instance
+                // This is what the test `should replace the list with a new array` expects.
+                setList([...newList])
             }
         },
         [setList],
@@ -81,7 +79,7 @@ export function useList<T>(initialList: T[] = []): UseListReturn<T> {
 
     const insertMany = useCallback(
         (items: T[]) => {
-            if (!Array.isArray(items) || items.length === 0) return // Verifica si items es un array no vacío
+            if (!Array.isArray(items) || items.length === 0) return // Check if items is a non-empty array
             setListCallback((currentList) => [...currentList, ...items])
         },
         [setListCallback],
@@ -321,6 +319,15 @@ export function useList<T>(initialList: T[] = []): UseListReturn<T> {
         [setListCallback],
     )
 
+    const reverse = useCallback(() => {
+        setListCallback((currentList) => {
+            if (currentList.length <= 1) {
+                return currentList
+            }
+            return [...currentList].reverse()
+        })
+    }, [setListCallback])
+
     return {
         list,
         addItem,
@@ -343,6 +350,7 @@ export function useList<T>(initialList: T[] = []): UseListReturn<T> {
         sort,
         shuffle,
         swap,
+        reverse,
     }
 }
 
@@ -404,4 +412,6 @@ interface UseListReturn<T> {
     shuffle: () => void
     /** Swaps two items in the list immutably based on their indices. */
     swap: (indexA: number, indexB: number) => void
+    /** Reverses the order of the items in the list immutably. */
+    reverse: () => void
 }


### PR DESCRIPTION
💡 **What:** Added an immutable `reverse()` method to the `useList` hook.

🎯 **Why:** To provide a fundamental array operation that was missing from the hook's suite of reordering helpers, improving developer experience when flipping list order.

📦 **What it adds:**
- `reverse: () => void` in the `useList` return object.
- JSDoc documentation for the new method.
- Performance optimization: returns the original array instance if reversing an empty or single-item list.

🚀 **How to use:**
```tsx
const { list, reverse } = useList(['a', 'b', 'c']);
// ...
reverse(); // list becomes ['c', 'b', 'a']
```

♻️ **Deps Free:** Uses only React's `useCallback` and native JavaScript array methods.

🎨 **Harmony:** Fits perfectly with the existing `sort`, `shuffle`, `move`, and `swap` methods in the `useList` API and follows the established immutable state pattern. Additionally, legacy Spanish comments in the modified file were translated to English to match the project's standards.

---
*PR created automatically by Jules for task [8025835357462517511](https://jules.google.com/task/8025835357462517511) started by @galiprandi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `useList` hook now provides a `reverse()` method that immutably reverses the list order while properly handling edge cases such as single-item and empty lists.

* **Documentation**
  * Documentation has been updated to reflect and document the new `reverse()` method functionality for the `useList` hook and its behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galiprandi/react-tools/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->