### PR TITLE
⚡ Spark: useList upsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -1081,6 +1081,7 @@ An object containing the current array state (`list`) and helper functions to mo
 | `contains`      | `(key: string \| undefined \| null, value: any) => boolean` | Checks if **any** item matches `item[key] === value`. If `key` is `undefined` or `null`, checks if `item === value`. Returns `true` if found, `false` otherwise. |
 | `count`          | `(predicate?: (item: T) => boolean) => number`              | Returns the total number of items in the list, or the count of items matching an optional `predicate`. Does not modify the list.       |
 | `toggle`         | `(item: T, key?: string \| undefined \| null) => void`      | Adds an item if it's not present, or removes it if it is, based on an optional key or reference comparison. |
+| `upsert`         | `(item: T, key?: string \| undefined \| null) => void`      | Adds an item if it's not present, or updates the existing one if it is, based on an optional key or reference comparison. |
 | `move`           | `(fromIndex: number, toIndex: number) => void`              | Moves an item from `fromIndex` to `toIndex` immutably. If indices are out of bounds or identical, the list remains unchanged. |
 | `sort`           | `(keyOrCompareFn?: string \| ((a: T, b: T) => number) \| null, order?: 'asc' \| 'desc') => void` | Sorts the list immutably using an optional key or comparison function, and an optional sort order. |
 | `shuffle`        | `() => void`                                                | Randomly reorders the list items immutably. |

--- a/lib/hooks/useList.test.ts
+++ b/lib/hooks/useList.test.ts
@@ -849,6 +849,80 @@ describe('useList', () => {
         })
     })
 
+    describe('upsert', () => {
+        it('should add a primitive item if it is not in the list', () => {
+            const { result } = renderHook(() => useList<string>(['a', 'b']))
+            act(() => {
+                result.current.upsert('c')
+            })
+            expect(result.current.list).toEqual(['a', 'b', 'c'])
+        })
+
+        it('should update a primitive item if it is in the list', () => {
+            const { result } = renderHook(() => useList<string>(['a', 'b', 'c']))
+            act(() => {
+                result.current.upsert('b')
+            })
+            expect(result.current.list).toEqual(['a', 'b', 'c'])
+            // Even if same value, it should be a new array instance because of setListCallback
+        })
+
+        it('should add an object if it is not in the list (by reference)', () => {
+            const item1 = { id: 1, name: 'a' }
+            const item2 = { id: 2, name: 'b' }
+            const { result } = renderHook(() => useList([item1]))
+            act(() => {
+                result.current.upsert(item2)
+            })
+            expect(result.current.list).toEqual([item1, item2])
+        })
+
+        it('should update an object if it is in the list (by reference)', () => {
+            const item1 = { id: 1, name: 'a' }
+            const item2 = { id: 2, name: 'b' }
+            const { result } = renderHook(() => useList([item1, item2]))
+            act(() => {
+                result.current.upsert(item2)
+            })
+            expect(result.current.list).toEqual([item1, item2])
+            expect(result.current.list[1]).toBe(item2)
+        })
+
+        it('should add an object if it is not in the list (by key)', () => {
+            const item1 = { id: 1, name: 'a' }
+            const { result } = renderHook(() => useList([item1]))
+            act(() => {
+                result.current.upsert({ id: 2, name: 'other' }, 'id')
+            })
+            expect(result.current.list).toEqual([
+                item1,
+                { id: 2, name: 'other' },
+            ])
+        })
+
+        it('should update an object if it is in the list (by key)', () => {
+            const item1 = { id: 1, name: 'a' }
+            const item2 = { id: 2, name: 'b' }
+            const { result } = renderHook(() => useList([item1, item2]))
+            const newItem2 = { id: 2, name: 'updated' }
+            act(() => {
+                result.current.upsert(newItem2, 'id')
+            })
+            expect(result.current.list).toEqual([item1, newItem2])
+            expect(result.current.list[1]).toBe(newItem2)
+            expect(result.current.list[1]).not.toBe(item2)
+        })
+
+        it('should always add if key is restricted', () => {
+            const { result } = renderHook(() => useList<any>([{ id: 1 }]))
+            act(() => {
+                result.current.upsert({ constructor: 'malicious' }, 'constructor')
+            })
+            expect(result.current.list).toHaveLength(2)
+            expect(result.current.list[1]).toEqual({ constructor: 'malicious' })
+        })
+    })
+
     describe('move', () => {
         it('should move an item forward in the list', () => {
             const { result } = renderHook(() => useList(['a', 'b', 'c']))

--- a/lib/hooks/useList.tsx
+++ b/lib/hooks/useList.tsx
@@ -345,6 +345,27 @@ export function useList<T>(initialList: T[] = []): UseListReturn<T> {
         })
     }, [setListCallback])
 
+    const upsert = useCallback(
+        (item: T, key?: string | undefined | null) => {
+            const value = getValueToCompare(item, key)
+            setListCallback((currentList) => {
+                const index =
+                    value === RESTRICTED_SYMBOL
+                        ? -1
+                        : currentList.findIndex(
+                              (i) => getValueToCompare(i, key) === value,
+                          )
+
+                if (index === -1) {
+                    return [...currentList, item]
+                }
+
+                return currentList.map((i, idx) => (idx === index ? item : i))
+            })
+        },
+        [setListCallback],
+    )
+
     return {
         list,
         addItem,
@@ -365,6 +386,7 @@ export function useList<T>(initialList: T[] = []): UseListReturn<T> {
         contains,
         count,
         toggle,
+        upsert,
         move,
         sort,
         shuffle,
@@ -424,6 +446,8 @@ interface UseListReturn<T> {
     count: (predicate?: (item: T) => boolean) => number
     /** Adds an item if it's not present, or removes it if it is, based on an optional key or reference comparison. */
     toggle: (item: T, key?: string | undefined | null) => void
+    /** Adds an item if it's not present, or updates the existing one if it is, based on an optional key or reference comparison. */
+    upsert: (item: T, key?: string | undefined | null) => void
     /** Moves an item from one index to another immutably. */
     move: (fromIndex: number, toIndex: number) => void
     /** Sorts the list immutably using an optional key or comparison function, and an optional sort order. */


### PR DESCRIPTION
💡 **What:** Added `upsert` method to `useList` hook.
🎯 **Why:** To simplify the common pattern of adding an item if it doesn't exist or updating it if it does.
📦 **What it adds:** `upsert(item: T, key?: string | undefined | null)` to the `useList` API.
🚀 **How to use:** `list.upsert({ id: 1, name: 'Updated' }, 'id')`
♻️ **Deps Free:** Yes, uses only existing React and internal utilities.
🎨 **Harmony:** Follows existing `toggle` and `updateBy` patterns.

---
*PR created automatically by Jules for task [16878155499140885027](https://jules.google.com/task/16878155499140885027) started by @galiprandi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `upsert` method to the list hook, allowing insertion of new items or updates to existing ones based on optional key comparison.

* **Documentation**
  * Updated hook documentation to include the new `upsert` method and its behavior.

* **Tests**
  * Added comprehensive test suite verifying `upsert` behavior with primitives, objects, and custom key comparisons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galiprandi/react-tools/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->