### PR TITLE
✨ Quality: robustness - improve Observer and Dialog components

### DIFF
--- a/.axioma/quality.md
+++ b/.axioma/quality.md
@@ -29,3 +29,11 @@
 ## 2025-05-30 - [Deterministic Date Testing]
 **Learning:** Tests for date conversion utilities like `iso2LocalDateTime` are sensitive to the execution environment's timezone; mock `Date.prototype.getTimezoneOffset` using Vitest spies (`vi.spyOn(...).mockReturnValue(...)`) to achieve deterministic test outcomes across different environments.
 **Action:** Always mock the timezone offset when testing date-to-local-string conversions to prevent flaky tests in CI.
+
+## 2024-06-05 - [Robust Browser API Wrapping]
+**Learning:** Components wrapping browser APIs (like `IntersectionObserver` or `HTMLDialogElement`) should use `useRef` to stabilize callbacks and avoid stale closures without triggering effect re-runs. For `Dialog`, checking the native `open` property before calling methods like `showModal()` prevents `InvalidStateError` and redundant state updates.
+**Action:** Use the "latest ref" pattern for event callbacks in wrapper components and always verify native element state before invoking state-changing methods.
+
+## 2024-06-05 - [Mocking Dialog State in Tests]
+**Learning:** In 'happy-dom', when mocking `HTMLDialogElement` methods, it's crucial to also update the `open` attribute of the element within the mock (e.g., `this.setAttribute('open', '')`). Otherwise, any component logic that checks `dialog.open` after calling a method will receive stale information, leading to incorrect test results.
+**Action:** Ensure mocks for native methods also update the underlying DOM state that the component depends on.

--- a/lib/components/Dialog/index.test.tsx
+++ b/lib/components/Dialog/index.test.tsx
@@ -5,9 +5,16 @@ import { Dialog } from './index'
 describe('Dialog', () => {
     beforeEach(() => {
         // Mocking HTMLDialogElement methods as they are not implemented in happy-dom
-        HTMLDialogElement.prototype.show = vi.fn()
-        HTMLDialogElement.prototype.showModal = vi.fn()
-        HTMLDialogElement.prototype.close = vi.fn()
+        // We also need to mock the 'open' property behavior
+        vi.spyOn(HTMLDialogElement.prototype, 'show').mockImplementation(function (this: HTMLDialogElement) {
+            this.setAttribute('open', '')
+        })
+        vi.spyOn(HTMLDialogElement.prototype, 'showModal').mockImplementation(function (this: HTMLDialogElement) {
+            this.setAttribute('open', '')
+        })
+        vi.spyOn(HTMLDialogElement.prototype, 'close').mockImplementation(function (this: HTMLDialogElement) {
+            this.removeAttribute('open')
+        })
     })
 
     it('should render correctly with children', () => {
@@ -116,5 +123,27 @@ describe('Dialog', () => {
         expect(dialog?.className).toContain('custom-dialog')
         expect(dialog?.getAttribute('id')).toBe('my-dialog')
         expect(dialog?.getAttribute('aria-labelledby')).toBe('dialog-title')
+    })
+
+    it('should not redundantly call native methods when re-rendered with new callback instances', () => {
+        const onOpen1 = vi.fn()
+        const onOpen2 = vi.fn()
+
+        const { rerender } = render(
+            <Dialog isOpen={true} onOpen={onOpen1}>
+                <p>Content</p>
+            </Dialog>
+        )
+
+        expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalledTimes(1)
+
+        rerender(
+            <Dialog isOpen={true} onOpen={onOpen2}>
+                <p>Content</p>
+            </Dialog>
+        )
+
+        // It should still be 1 because it's already open
+        expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalledTimes(1)
     })
 })

--- a/lib/components/Dialog/index.tsx
+++ b/lib/components/Dialog/index.tsx
@@ -49,15 +49,21 @@ export const Dialog = (props: DialogProps): JSX.Element => {
     }, [isOpen])
 
     useEffect(() => {
-        if (!dialog.current) return
+        const dialogElement = dialog.current
+        if (!dialogElement) return
+
         if (open) {
-            behavior === 'dialog'
-                ? dialog.current.show()
-                : dialog.current.showModal()
-            onOpen?.()
+            if (!dialogElement.open) {
+                behavior === 'dialog'
+                    ? dialogElement.show()
+                    : dialogElement.showModal()
+                onOpen?.()
+            }
         } else {
-            dialog.current.close()
-            onClose?.()
+            if (dialogElement.open) {
+                dialogElement.close()
+                onClose?.()
+            }
         }
     }, [open, behavior, onOpen, onClose])
 

--- a/lib/components/Observer/index.test.tsx
+++ b/lib/components/Observer/index.test.tsx
@@ -222,4 +222,50 @@ describe('Observer Component', () => {
             expect.objectContaining({ rootMargin: '50px' })
         )
     })
+
+    it('should use the latest callback even if it changes after mount', () => {
+        const onAppear1 = vi.fn()
+        const onAppear2 = vi.fn()
+        const mockEntry = { isIntersecting: true }
+
+        const { rerender } = render(
+            <Observer onAppear={onAppear1}>
+                <p>Test Content</p>
+            </Observer>
+        )
+
+        // Change the callback
+        rerender(
+            <Observer onAppear={onAppear2}>
+                <p>Test Content</p>
+            </Observer>
+        )
+
+        const callback = mockIntersectionObserver.mock.calls[0][0]
+        callback([mockEntry])
+
+        expect(onAppear1).not.toHaveBeenCalled()
+        expect(onAppear2).toHaveBeenCalledWith(mockEntry)
+    })
+
+    it('should not recreate IntersectionObserver when callbacks change', () => {
+        const onAppear1 = vi.fn()
+        const onAppear2 = vi.fn()
+
+        const { rerender } = render(
+            <Observer onAppear={onAppear1}>
+                <p>Test Content</p>
+            </Observer>
+        )
+
+        expect(mockIntersectionObserver).toHaveBeenCalledTimes(1)
+
+        rerender(
+            <Observer onAppear={onAppear2}>
+                <p>Test Content</p>
+            </Observer>
+        )
+
+        expect(mockIntersectionObserver).toHaveBeenCalledTimes(1)
+    })
 })

--- a/lib/components/Observer/index.tsx
+++ b/lib/components/Observer/index.tsx
@@ -37,24 +37,44 @@ export const Observer = (props: ObserverProps): ObserverReturn => {
         onAppear,
         onDisappear,
         children,
-        ...options
+        root,
+        rootMargin,
+        threshold,
     } = props
     const ref = useRef<HTMLDivElement>(null)
+    const onAppearRef = useRef(onAppear)
+    const onDisappearRef = useRef(onDisappear)
 
-    const callbackFunction = ([entry]: IntersectionObserverEntry[]) => {
-        if (entry.isIntersecting && onAppear) onAppear(entry)
-        if (!entry.isIntersecting && onDisappear) onDisappear(entry)
-    }
+    // Update refs to always point to the latest callbacks
+    useEffect(() => {
+        onAppearRef.current = onAppear
+        onDisappearRef.current = onDisappear
+    }, [onAppear, onDisappear])
 
     useEffect(() => {
-        const observer = new IntersectionObserver(callbackFunction, options)
+        const callbackFunction = ([entry]: IntersectionObserverEntry[]) => {
+            if (entry.isIntersecting && onAppearRef.current) {
+                onAppearRef.current(entry)
+            }
+            if (!entry.isIntersecting && onDisappearRef.current) {
+                onDisappearRef.current(entry)
+            }
+        }
+
+        const observer = new IntersectionObserver(callbackFunction, {
+            root,
+            rootMargin,
+            threshold,
+        })
+
         const currentRef = ref.current
         if (currentRef) observer.observe(currentRef)
 
         return () => {
             if (currentRef) observer.unobserve(currentRef)
+            observer.disconnect()
         }
-    }, [ref, options])
+    }, [root, rootMargin, threshold])
 
     // eslint-disable-next-line react/no-children-prop
     return createElement(wrapper, { ref, children })


### PR DESCRIPTION
💡 What:
- Implemented "latest ref" pattern for callbacks in `Observer` to prevent stale closures and unnecessary observer recreations.
- Added guards to `Dialog` to check the native `open` property before calling state-changing methods (`showModal`, `close`), preventing `InvalidStateError`.
- Improved test coverage and mocking for both components.
- Updated Quality Journal with technical learnings.

🎯 Why:
- `Observer` was prone to stale closures if callbacks changed, or unnecessary re-initialization of the native API.
- `Dialog` could crash or trigger redundant callbacks if native methods were called when the dialog was already in the target state.

📊 Impact:
- More reliable interaction with browser-native APIs.
- Better test stability and accuracy.
- Reduced risk of runtime errors in edge cases.

✅ Verification:
- All 363 unit tests passed.
- Visual verification in the playground using Playwright.
- Code review confirmed adherence to best practices.

---
*PR created automatically by Jules for task [15569542127944952050](https://jules.google.com/task/15569542127944952050) started by @galiprandi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved callback handling issues in Dialog and Observer components to prevent stale closures and unnecessary re-executions.
  * Improved Dialog component's native API integration for more reliable open/close behavior.

* **Tests**
  * Enhanced Dialog component mocking for accurate API behavior verification in tests.
  * Added Observer component tests for callback updates and observer lifecycle.

* **Documentation**
  * Updated development guidelines on browser API wrapper correctness and testing best practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galiprandi/react-tools/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->