### PR TITLE
⚡ Spark: support ISO strings for min and max in DateTime

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -21,3 +21,7 @@
 ## 2026-05-20 - [No-op Optimizations in Immutable State]
 **Learning:** For list manipulation hooks, implementing no-op checks (returning the original state reference) for operations that would result in an identical array (e.g., reversing a single-item list or swapping out-of-bounds indices) prevents unnecessary React re-renders and improves performance.
 **Pattern:** Always check for edge cases where an operation results in no change and return the `currentList` reference immediately.
+
+## 2025-05-26 - [Shadowing standard props for ISO transforms]
+**Learning:** For components that wrap native HTML inputs, adding `iso*` variants of standard props (like `isoMin` for `min`) allows the component to handle standard data formats while gracefully falling back to native behavior when the specialized prop is absent.
+**Pattern:** Implement specialized props with an `iso` prefix and use a ternary in the render function to prioritize the transformed ISO value: `min={isoMin ? iso2LocalDateTime(isoMin) : min}`.

--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ A wrapper around `<input type="datetime-local" />` that handles ISO string conve
 |---------------------|-----------------------------------|------------------------------------------|
 | `isoValue`          | `string`                          | ISO 8601 datetime value                 |
 | `onChangeISOValue`  | `(iso: string) => void`           | Callback with ISO string                |
+| `isoMin`            | `string`                          | Minimum date/time in ISO 8601 format    |
+| `isoMax`            | `string`                          | Maximum date/time in ISO 8601 format    |
 | `...InputProps`     | All `<Input />` props             | Inherits all Input behavior             |
 
 ***

--- a/lib/components/DateTime/index.test.tsx
+++ b/lib/components/DateTime/index.test.tsx
@@ -99,4 +99,29 @@ describe('<DateTime />', () => {
         expect(container.querySelector('datalist')).toBeDefined()
         expect(container.querySelectorAll('option')).toHaveLength(datalist.length)
     })
+
+    it('should support ISO strings for min and max props', () => {
+        // Mock timezone offset to UTC (0) for deterministic results
+        const tzSpy = vi
+            .spyOn(Date.prototype, 'getTimezoneOffset')
+            .mockReturnValue(0)
+
+        const testId = 'test-8'
+        const min = '2021-01-01T00:00:00Z'
+        const max = '2021-12-31T23:59:59Z'
+        const { getByTestId } = render(
+            <DateTime
+                data-testid={testId}
+                isoValue="2021-06-01T12:00:00Z"
+                isoMin={min}
+                isoMax={max}
+            />,
+        )
+
+        const input = getByTestId(testId) as HTMLInputElement
+        expect(input.min).toBe('2021-01-01T00:00')
+        expect(input.max).toBe('2021-12-31T23:59')
+
+        tzSpy.mockRestore()
+    })
 })

--- a/lib/components/DateTime/index.tsx
+++ b/lib/components/DateTime/index.tsx
@@ -31,7 +31,8 @@ import { Input } from '../Input'
  * ```
  */
 export const DateTime = (props: DateTimeProps): JSX.Element => {
-    const { isoValue, onChangeISOValue, ...restProps } = props
+    const { isoValue, onChangeISOValue, isoMin, isoMax, min, max, ...restProps } =
+        props
     const [isoDateTime, setIsoDateTime] =
         useState<DateTimeProps['isoValue']>(isoValue)
 
@@ -47,6 +48,8 @@ export const DateTime = (props: DateTimeProps): JSX.Element => {
         <Input
             {...restProps}
             type="datetime-local"
+            min={isoMin ? iso2LocalDateTime(isoMin) : min}
+            max={isoMax ? iso2LocalDateTime(isoMax) : max}
             value={isoDateTime ? iso2LocalDateTime(isoDateTime) : props.value}
             onChangeValue={(value) =>
                 typeof value === 'string'
@@ -65,6 +68,8 @@ export const DateTime = (props: DateTimeProps): JSX.Element => {
  *
  * @property {string} [isoValue] - The ISO date-time string value.
  * @property {(value: string) => void} [onChangeISOValue] - Callback function triggered when the ISO date-time value changes.
+ * @property {string} [isoMin] - The minimum date and time allowed in ISO 8601 format.
+ * @property {string} [isoMax] - The maximum date and time allowed in ISO 8601 format.
  */
 export interface DateTimeProps
     extends Omit<ComponentProps<typeof Input>, 'type'> {
@@ -78,4 +83,12 @@ export interface DateTimeProps
      * @param {string} value - The new ISO date-time value in format "YYYY-MM-DDTHH:MM:SS.sssZ".
      */
     onChangeISOValue?: (value: string) => void
+    /**
+     * The minimum date and time allowed in ISO 8601 format.
+     */
+    isoMin?: string
+    /**
+     * The maximum date and time allowed in ISO 8601 format.
+     */
+    isoMax?: string
 }


### PR DESCRIPTION
💡 **What:** Added `isoMin` and `isoMax` props to the `DateTime` component.
🎯 **Why:** Allows developers to set date boundaries using standard ISO 8601 strings (e.g., from databases) without manual local conversion.
📦 **What it adds:** Two new optional props: `isoMin` and `isoMax`.
🚀 **How to use:** `<DateTime isoMin="2021-01-01T00:00:00Z" isoMax={new Date().toISOString()} />`
♻️ **Deps Free:** Uses only existing `iso2LocalDateTime` utility.
🎨 **Harmony:** Matches the existing `isoValue` pattern and provides fallback to standard `min`/`max` props.

---
*PR created automatically by Jules for task [13075608049118068566](https://jules.google.com/task/13075608049118068566) started by @galiprandi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * DateTime component now supports `isoMin` and `isoMax` props to specify minimum and maximum allowed datetime values in ISO 8601 format, with automatic conversion to local datetime format.

* **Documentation**
  * Updated README with new DateTime props documentation.
  * Added guidance on shadowing HTML input props with `iso*` variants.

* **Tests**
  * Added unit tests for `isoMin` and `isoMax` functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/galiprandi/react-tools/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->