### PR TITLE
⚡ Spark: useList rotate method

### DIFF
--- a/.axioma/spark.md
+++ b/.axioma/spark.md
@@ -41,3 +41,7 @@
 ## 2026-05-28 - [Predicate-Based List Manipulation]
 **Learning:** Adding functional methods like `removeWhere` and `updateWhere` to a list management hook (`useList`) significantly increases its expressiveness compared to index-based or property-based operations alone. By using a stable `setListCallback`, these methods maintain high performance and prevent unnecessary re-renders when no matches are found.
 **Pattern:** Implement functional list operations by wrapping `filter` and `map` with predicate checks, and always perform a length or equality check before calling the state setter to ensure a no-op when no items are affected.
+
+## 2026-05-29 - [Normalized Circular Operations]
+**Learning:** When implementing circular operations like `rotate` on arrays, using a double-modulo pattern `((offset % length) + length) % length` ensures the offset is correctly normalized to a positive value regardless of whether the input is positive or negative, simplifying the slicing logic.
+**Pattern:** Normalize directional offsets with `((n % len) + len) % len` before performing immutable array manipulations to robustly handle both "forward" and "backward" operations with a single logic path.

--- a/README.md
+++ b/README.md
@@ -1093,6 +1093,7 @@ An object containing the current array state (`list`) and helper functions to mo
 | `shuffle`        | `() => void`                                                | Randomly reorders the list items immutably. |
 | `swap`           | `(indexA: number, indexB: number) => void`                  | Swaps two items in the list immutably based on their indices. |
 | `reverse`         | `() => void`                                                | Reverses the order of the items in the list immutably. |
+| `rotate`          | `(offset: number) => void`                                  | Rotates the list items by a given offset immutably. |
 
 ***
 

--- a/lib/hooks/useList.test.ts
+++ b/lib/hooks/useList.test.ts
@@ -1349,4 +1349,93 @@ describe('useList', () => {
             expect(result.current.list).not.toBe(originalList)
         })
     })
+
+    describe('rotate', () => {
+        it('should rotate the list items to the right with a positive offset', () => {
+            const { result } = renderHook(() => useList(['a', 'b', 'c', 'd']))
+            act(() => {
+                result.current.rotate(1)
+            })
+            expect(result.current.list).toEqual(['d', 'a', 'b', 'c'])
+
+            act(() => {
+                result.current.rotate(1)
+            })
+            expect(result.current.list).toEqual(['c', 'd', 'a', 'b'])
+        })
+
+        it('should rotate the list items to the left with a negative offset', () => {
+            const { result } = renderHook(() => useList(['a', 'b', 'c', 'd']))
+            act(() => {
+                result.current.rotate(-1)
+            })
+            expect(result.current.list).toEqual(['b', 'c', 'd', 'a'])
+
+            act(() => {
+                result.current.rotate(-1)
+            })
+            expect(result.current.list).toEqual(['c', 'd', 'a', 'b'])
+        })
+
+        it('should handle offset larger than list length', () => {
+            const { result } = renderHook(() => useList(['a', 'b', 'c']))
+            act(() => {
+                result.current.rotate(4) // same as rotate(1)
+            })
+            expect(result.current.list).toEqual(['c', 'a', 'b'])
+
+            act(() => {
+                result.current.rotate(-4) // same as rotate(-1)
+            })
+            expect(result.current.list).toEqual(['a', 'b', 'c'])
+        })
+
+        it('should do nothing and keep same reference for offset 0', () => {
+            const initialList = ['a', 'b', 'c']
+            const { result } = renderHook(() => useList(initialList))
+            const originalList = result.current.list
+            act(() => {
+                result.current.rotate(0)
+            })
+            expect(result.current.list).toEqual(initialList)
+            expect(result.current.list).toBe(originalList)
+
+            act(() => {
+                result.current.rotate(3) // offset equals length
+            })
+            expect(result.current.list).toEqual(initialList)
+            expect(result.current.list).toBe(originalList)
+        })
+
+        it('should do nothing and keep same reference for empty list', () => {
+            const { result } = renderHook(() => useList<string>([]))
+            const originalList = result.current.list
+            act(() => {
+                result.current.rotate(1)
+            })
+            expect(result.current.list).toEqual([])
+            expect(result.current.list).toBe(originalList)
+        })
+
+        it('should do nothing and keep same reference for single item list', () => {
+            const { result } = renderHook(() => useList(['a']))
+            const originalList = result.current.list
+            act(() => {
+                result.current.rotate(1)
+            })
+            expect(result.current.list).toEqual(['a'])
+            expect(result.current.list).toBe(originalList)
+        })
+
+        it('should return a new list instance when rotated', () => {
+            const initialList = ['a', 'b']
+            const { result } = renderHook(() => useList(initialList))
+            const originalList = result.current.list
+            act(() => {
+                result.current.rotate(1)
+            })
+            expect(result.current.list).toEqual(['b', 'a'])
+            expect(result.current.list).not.toBe(originalList)
+        })
+    })
 })

--- a/lib/hooks/useList.tsx
+++ b/lib/hooks/useList.tsx
@@ -401,6 +401,24 @@ export function useList<T>(initialList: T[] = []): UseListReturn<T> {
         })
     }, [setListCallback])
 
+    const rotate = useCallback(
+        (offset: number) => {
+            setListCallback((currentList) => {
+                const length = currentList.length
+                if (length <= 1) return currentList
+
+                const normalizedOffset = ((offset % length) + length) % length
+                if (normalizedOffset === 0) return currentList
+
+                return [
+                    ...currentList.slice(length - normalizedOffset),
+                    ...currentList.slice(0, length - normalizedOffset),
+                ]
+            })
+        },
+        [setListCallback],
+    )
+
     const upsert = useCallback(
         (item: T, key?: string | undefined | null) => {
             const value = getValueToCompare(item, key)
@@ -451,6 +469,7 @@ export function useList<T>(initialList: T[] = []): UseListReturn<T> {
         shuffle,
         swap,
         reverse,
+        rotate,
     }
 }
 
@@ -529,4 +548,6 @@ interface UseListReturn<T> {
     swap: (indexA: number, indexB: number) => void
     /** Reverses the order of the items in the list immutably. */
     reverse: () => void
+    /** Rotates the list items by a given offset immutably. */
+    rotate: (offset: number) => void
 }


### PR DESCRIPTION
💡 **What:** Added a `rotate(offset: number)` method to the `useList` hook.
🎯 **Why:** Provides a simple, immutable way to shift items in a list, which is useful for carousels, cyclic queues, or reordering UI elements.
📦 **What it adds:** A new `rotate` function in the `UseListReturn<T>` interface.
🚀 **How to use:**
```tsx
const { list, rotate } = useList(['a', 'b', 'c']);
rotate(1); // list becomes ['c', 'a', 'b']
rotate(-1); // list becomes ['b', 'c', 'a']
```
♻️ **Deps Free:** Uses only built-in JavaScript array methods and React hooks.
🎨 **Harmony:** Follows the established immutable update pattern and "no-op on same state" optimization used throughout the `useList` hook.

---
*PR created automatically by Jules for task [12556088044139500984](https://jules.google.com/task/12556088044139500984) started by @galiprandi*