### PR TITLE
✨ Quality: test coverage - cover default limit in useThrottle

### DIFF
--- a/.axioma/quality.md
+++ b/.axioma/quality.md
@@ -53,3 +53,7 @@
 ## 2024-06-15 - [Exhaustive Coverage for Date Safeguards]
 **Learning:** Date utilities like `iso2LocalDateTime` require exhaustive testing of their error safeguards, such as the `catch` block for `toISOString` RangeErrors. Achieving 100% branch coverage often involves mocking prototype methods to throw or using boundary dates (e.g., `8.64e15`) that fail after timezone adjustment.
 **Action:** Use `vi.spyOn(Date.prototype, 'toISOString').mockImplementation()` to verify fallback behavior and always rely on `afterEach(() => vi.restoreAllMocks())` for robust cleanup.
+
+## 2024-06-20 - [Achieving Full Branch Coverage with Default Parameters]
+**Learning:** To achieve 100% branch coverage in hooks or functions that use default parameters (e.g., `useThrottle(value, limit = 500)`), unit tests must explicitly invoke the function without the optional arguments. Simply relying on tests that provide values for all arguments leaves the default assignment branch uncovered.
+**Action:** Always include a test case that omits optional arguments to ensure default parameter logic is verified and coverage is maximized.

--- a/lib/hooks/useThrottle.test.ts
+++ b/lib/hooks/useThrottle.test.ts
@@ -93,4 +93,28 @@ describe('useThrottle', () => {
         rerender({ val: 'updated 1', limit: 0 })
         expect(result.current).toBe('updated 1')
     })
+
+    it('should use default limit of 500ms when not provided', () => {
+        const { result, rerender } = renderHook(({ val }) => useThrottle(val), {
+            initialProps: { val: 'initial' },
+        })
+
+        expect(result.current).toBe('initial')
+
+        // Update value within default limit
+        rerender({ val: 'updated 1' })
+        expect(result.current).toBe('initial')
+
+        // Advance timers by less than the default limit
+        act(() => {
+            vi.advanceTimersByTime(400)
+        })
+        expect(result.current).toBe('initial')
+
+        // Advance timers to the default limit
+        act(() => {
+            vi.advanceTimersByTime(100)
+        })
+        expect(result.current).toBe('updated 1')
+    })
 })


### PR DESCRIPTION
💡 What: Added a test case for the default `limit` parameter in the `useThrottle` hook.
🎯 Why: The branch logic for the default parameter `limit = 500` was previously uncovered because all existing tests explicitly provided a limit.
📊 Impact: Increases branch coverage of `lib/hooks/useThrottle.ts` from 85.71% to 100% and ensures the default behavior is verified.
✅ Verification: Ran `pnpm test:coverage` and confirmed 100% branch coverage for `useThrottle.ts`. Verified all tests pass.

---
*PR created automatically by Jules for task [13922288236508572652](https://jules.google.com/task/13922288236508572652) started by @galiprandi*